### PR TITLE
光にRGBチャンネルの追加 / objectのメソッド周りの改善  🚶

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ norm:
 	norminette $(SRCS) $(HEADERS) | grep -E '^(Error|Warning)'
 
 norm-easy:
-	norminette $(SRCS) $(HEADERS) | grep -v WRONG_SCOPE_COMMENT | grep -v "Missing or invalid header"
+	norminette $(SRCS) $(HEADERS) | grep -v WRONG_SCOPE_COMMENT | grep -v LINE_TOO_LONG | grep -v "Missing or invalid header"
 
 run:
 	./$(NAME)

--- a/include/color.h
+++ b/include/color.h
@@ -1,0 +1,16 @@
+#ifndef COLOR_H
+# define COLOR_H
+
+typedef struct s_color {
+	double	r;
+	double	g;
+	double	b;
+}	t_color;
+
+int		color_to_int(t_color color);
+t_color	color(double r, double g, double b);
+t_color	color_add(t_color c1, t_color c2);
+t_color	color_mult(t_color c, double k);
+t_color	color_prod(t_color c1, t_color c2);
+
+#endif

--- a/include/light.h
+++ b/include/light.h
@@ -4,7 +4,7 @@
 # include "color.h"
 
 # define SHININESS 8
-# define SHININESS 8
+# define AMBIENT_REFLECTION_COEFFICIENT 0.01
 
 typedef struct s_light {
 	t_vector	coordinate;
@@ -12,12 +12,7 @@ typedef struct s_light {
 //	t_color		color;
 }	t_light;
 
-typedef struct s_ambient {
-	t_color		intensity;
-	t_color		reflection_coefficient;
-}	t_ambient;
-
-t_light		light(t_vector coordinate, t_color intensity);
-t_ambient	ambient(t_color intensity, t_color reflection_coefficient);
+t_light	light(t_vector coordinate, t_color intensity);
+t_color	ambient(t_color intensity);
 
 #endif //LIGHT_H

--- a/include/light.h
+++ b/include/light.h
@@ -1,15 +1,23 @@
 #ifndef LIGHT_H
 # define LIGHT_H
 
-# define AMBIENT_REFLECTION_COEFFICIENT 0.01
-# define DIFFUSE_REFLECTION_COEFFICIENT 0.69
-# define SPECULAR_REFLECTION_COEFFICIENT 0.3
-# define AMBIENT_INTENSITY 0.1
-# define LIGHT_INTENSITY 1.0
+# include "color.h"
+
+# define SHININESS 8
 # define SHININESS 8
 
-t_vector	init_light_point(void);
-double		calc_radiance(
-				t_vector center, t_vector cross_point, t_vector light_point);
+typedef struct s_light {
+	t_vector	coordinate;
+	t_color		intensity;
+//	t_color		color;
+}	t_light;
+
+typedef struct s_ambient {
+	t_color		intensity;
+	t_color		reflection_coefficient;
+}	t_ambient;
+
+t_light		light(t_vector coordinate, t_color intensity);
+t_ambient	ambient(t_color intensity, t_color reflection_coefficient);
 
 #endif //LIGHT_H

--- a/include/miniRT.h
+++ b/include/miniRT.h
@@ -26,7 +26,7 @@ typedef struct s_program {
 	t_img		img;
 	t_vector	camera_point;
 	t_light		light;
-	t_ambient	ambient;
+	t_color		ambient;
 	t_object	**object;
 }	t_program;
 

--- a/include/miniRT.h
+++ b/include/miniRT.h
@@ -3,6 +3,8 @@
 
 # include "vector.h"
 # include "object.h"
+# include "color.h"
+# include "light.h"
 
 // todo: this should be input from rt file
 # define WIDTH 512
@@ -23,17 +25,15 @@ typedef struct s_program {
 	void		*win;
 	t_img		img;
 	t_vector	camera_point;
-	t_vector	light_point;
-	t_object	object;
+	t_light		light;
+	t_ambient	ambient;
+	t_object	**object;
 }	t_program;
 
 // todo: create its header file when there are more funcs
 // image.c
 void		init_image(t_program *program, t_img *img);
 void		add_color_to_image(t_img *img, int color, int x, int y);
-
-// camera.c
-t_vector	init_camera_point(void);
 
 // utils.c
 int			rgb_to_int(double r, double g, double b);

--- a/include/object.h
+++ b/include/object.h
@@ -20,14 +20,14 @@ typedef struct s_object {
 /* Shape's operations (Shape's interface)... */
 void		object_ctor(t_object *me, t_vector center, t_color diffuse_reflection_coefficient, t_color specular_reflection_coefficient);
 double		object_solve_ray_equation(t_object *me, t_ray ray);
-t_color		object_calc_radiance(t_object *me, t_vector cross_point, t_light light, t_ambient amb);
+t_color		object_calc_radiance(t_object *me, t_vector cross_point, t_light light, t_color ambient);
 t_vector	object_calc_normal(t_object *me, t_vector cross_point);
 
 // Virtual table
 struct s_object_vtbl {
-	double		(*solve_ray_equation)(t_object *const me, t_ray ray);
-	t_color		(*calc_radiance)(t_object * const me, t_vector cross_point, t_light light, t_ambient amb);
-	t_vector	(*calc_normal)(t_object * const me, t_vector cross_point);
+	double		(*solve_ray_equation)(t_object *const me, t_ray);
+	t_color		(*calc_radiance)(t_object * const me, t_vector, t_light, t_color);
+	t_vector	(*calc_normal)(t_object * const me, t_vector);
 };
 
 // sphere

--- a/include/object.h
+++ b/include/object.h
@@ -3,6 +3,8 @@
 
 # include "vector.h"
 # include "ray.h"
+# include "color.h"
+# include "light.h"
 
 // Object
 /* forward declaration */
@@ -11,18 +13,21 @@ typedef struct s_object_vtbl	t_object_vtbl;
 typedef struct s_object {
 	t_object_vtbl	*vptr; /* <== Object's Virtual Pointer */
 	t_vector		center; // described as pc
+	t_color			diffuse_reflection_coefficient;
+	t_color			specular_reflection_coefficient;
 }	t_object;
 
 /* Shape's operations (Shape's interface)... */
-void	object_ctor(t_object *me, t_vector center);
-double	object_solve_ray_equation(t_object *me, t_ray ray);
-int		object_raytrace(t_object *me, t_vector cross_point, t_vector light);
+void		object_ctor(t_object *me, t_vector center, t_color diffuse_reflection_coefficient, t_color specular_reflection_coefficient);
+double		object_solve_ray_equation(t_object *me, t_ray ray);
+t_color		object_calc_radiance(t_object *me, t_vector cross_point, t_light light, t_ambient amb);
+t_vector	object_calc_normal(t_object *me, t_vector cross_point);
 
 // Virtual table
 struct s_object_vtbl {
-	double	(*solve_ray_equation)(t_object *const me, t_ray ray);
-	int		(*raytrace)(t_object *const me,
-			t_vector cross_point, t_vector light);
+	double		(*solve_ray_equation)(t_object *const me, t_ray ray);
+	t_color		(*calc_radiance)(t_object * const me, t_vector cross_point, t_light light, t_ambient amb);
+	t_vector	(*calc_normal)(t_object * const me, t_vector cross_point);
 };
 
 // sphere
@@ -33,6 +38,8 @@ typedef struct s_sphere {
 	double		radius;
 }	t_sphere;
 
-void	sphere_ctor(t_sphere *me, double radius, t_vector center);
+void		sphere_ctor(t_sphere *me, double radius, t_vector center, t_color diffuse_reflection_coefficient, t_color specular_reflection_coefficient);
+t_color		calc_radiance_diffuse(t_object *obj, t_vector cross_point, t_light light);
+t_color		calc_radiance_specular(t_object *obj, t_vector cross_point, t_light light);
 
 #endif

--- a/src/camera.c
+++ b/src/camera.c
@@ -1,6 +1,0 @@
-#include "../include/vector.h"
-
-t_vector	init_camera_point(void)
-{
-	return (vec_init(0, 0, -5));
-}

--- a/src/color.c
+++ b/src/color.c
@@ -43,7 +43,7 @@ t_color	color_mult(t_color c, double k)
 
 t_color	color_prod(t_color c1, t_color c2)
 {
-	t_color rtn;
+	t_color	rtn;
 
 	rtn.r = c1.r * c2.r;
 	rtn.g = c1.g * c2.g;

--- a/src/color.c
+++ b/src/color.c
@@ -1,0 +1,52 @@
+#include "../include/color.h"
+
+int	color_to_int(t_color color)
+{
+	int	rtn;
+
+	rtn = 0;
+	rtn |= (int)(color.b * 255);
+	rtn |= (int)(color.g * 255) << 8;
+	rtn |= (int)(color.r * 255) << 16;
+	return (rtn);
+}
+
+t_color	color(double r, double g, double b)
+{
+	t_color	rtn;
+
+	rtn.r = r;
+	rtn.g = g;
+	rtn.b = b;
+	return (rtn);
+}
+
+t_color	color_add(t_color c1, t_color c2)
+{
+	t_color	rtn;
+
+	rtn.r = c1.r + c2.r;
+	rtn.g = c1.g + c2.g;
+	rtn.b = c1.b + c2.b;
+	return (rtn);
+}
+
+t_color	color_mult(t_color c, double k)
+{
+	t_color	rtn;
+
+	rtn.r = c.r * k;
+	rtn.g = c.g * k;
+	rtn.b = c.b * k;
+	return (rtn);
+}
+
+t_color	color_prod(t_color c1, t_color c2)
+{
+	t_color rtn;
+
+	rtn.r = c1.r * c2.r;
+	rtn.g = c1.g * c2.g;
+	rtn.b = c1.b * c2.b;
+	return (rtn);
+}

--- a/src/light.c
+++ b/src/light.c
@@ -11,12 +11,7 @@ t_light	light(t_vector coordinate, t_color intensity)
 	return (l);
 }
 
-t_ambient	ambient(t_color intensity, t_color reflection_coefficient)
+t_color	ambient(t_color intensity)
 {
-	const t_ambient	a = {
-			.reflection_coefficient = reflection_coefficient,
-			.intensity = intensity,
-	};
-
-	return (a);
+	return (color_mult(intensity, AMBIENT_REFLECTION_COEFFICIENT));
 }

--- a/src/light.c
+++ b/src/light.c
@@ -1,73 +1,22 @@
-#include <math.h>
 #include "../include/vector.h"
 #include "../include/light.h"
-#include "../include/math.h"
 
-t_vector	init_light_point(void)
+t_light	light(t_vector coordinate, t_color intensity)
 {
-	return (vec_init(-5, 5, -5));
+	const t_light	l = {
+			.coordinate = coordinate,
+			.intensity = intensity,
+	};
+
+	return (l);
 }
 
-double	calc_radiance_diffuse(
-			t_vector center, t_vector cross_point, t_vector light_point)
+t_ambient	ambient(t_color intensity, t_color reflection_coefficient)
 {
-	t_vector		vec;
-	const t_vector	normal = ({
-		vec = vec_sub(cross_point, center);
-		vec_normalize(vec);
-	});
-	const t_vector	incident_direction = ({
-		vec = vec_sub(light_point, cross_point);
-		vec_normalize(vec);
-	});
-	double			radiance_diffuse;
+	const t_ambient	a = {
+			.reflection_coefficient = reflection_coefficient,
+			.intensity = intensity,
+	};
 
-	radiance_diffuse = 0;
-	if (vec_inner_product(normal, incident_direction) > 0)
-		radiance_diffuse = vec_inner_product(normal, incident_direction)
-			* DIFFUSE_REFLECTION_COEFFICIENT * LIGHT_INTENSITY;
-	return (radiance_diffuse);
-}
-
-double	calc_radiance_specular(
-			t_vector center, t_vector cross_point, t_vector light_point)
-{
-	t_vector		vec;
-	double			radiance_specular;
-	const t_vector	normal = ({
-		vec = vec_sub(cross_point, center);
-		vec_normalize(vec);
-	});
-	const t_vector	incident_direction = ({
-		vec = vec_sub(light_point, cross_point);
-		vec_normalize(vec);
-	});
-	const t_vector	specular = ({
-		vec = vec_mult(normal, 2 * vec_inner_product(normal, incident_direction));
-		vec_sub(vec, incident_direction);
-	});
-
-	radiance_specular = ({
-			vec = vec_mult(cross_point, -1);
-			vec = vec_normalize(vec);
-			pow(vec_inner_product(vec, specular), SHININESS)
-				* SPECULAR_REFLECTION_COEFFICIENT * LIGHT_INTENSITY;
-	});
-	radiance_specular = max(radiance_specular, 0);
-	return (radiance_specular);
-}
-
-double	calc_radiance(
-		t_vector center, t_vector cross_point, t_vector light_point)
-{
-	double	radiance;
-	double	rd;
-	double	ra;
-	double	rs;
-
-	ra = AMBIENT_REFLECTION_COEFFICIENT * AMBIENT_INTENSITY;
-	rd = calc_radiance_diffuse(center, cross_point, light_point);
-	rs = calc_radiance_specular(center, cross_point, light_point);
-	radiance = ra + rd + rs;
-	return (radiance);
+	return (a);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -1,14 +1,28 @@
+#include <printf.h>
+#include <stdlib.h>
 #include "../minilibx-linux/mlx.h"
 #include "../include/vector.h"
 #include "../include/miniRT.h"
 #include "../include/light.h"
 
 #define BACKGROUND 0x6495ED
+#define OBJECT_NUM 1
 
 void	init_program(t_program *program)
 {
 	program->mlx = mlx_init();
 	program->win = mlx_new_window(program->mlx, WIDTH, HEIGHT, "miniRT");
+	init_image(program, &program->img);
+	// camera setup
+	program->camera_point = vec_init(0, 0, -5);
+	// light setup
+	program->light = light(vec_init(-5, 5, -5), color(1.0, 1.0, 1.0));
+	program->ambient = ambient(color(0.1, 0.1, 0.1), color(0.01, 0.01, 0.01));
+	// object setup
+	// todo: malloc check, malloc free
+	program->object = malloc(sizeof(t_object *) * OBJECT_NUM);
+	program->object[0] = (t_object *)malloc(sizeof(t_sphere));
+	sphere_ctor((t_sphere *)program->object[0], 1.0, vec_init(0, 0, 5), color(0.69, 0.0, 0.0), color(0.3, 0.3, 0.3));
 }
 
 // https://knzw.tech/raytracing/?page_id=1243
@@ -26,19 +40,18 @@ void	draw(t_program *program, int x, int y)
 	t_ray		ray;
 	double		ray_coefficient;
 	t_vector	cross_point;
-	int			color;
+	t_color		color;
 
 	screen_point = init_screen_point(x, y);
 	ray.start = program->camera_point;
 	ray.direction = vec_sub(screen_point, program->camera_point);
-	ray_coefficient = object_solve_ray_equation(&program->object, ray);
+	ray_coefficient = object_solve_ray_equation(program->object[0], ray);
 	if (ray_coefficient >= 0)
 	{
 		cross_point = vec_add(ray.start,
 				  vec_mult(ray.direction, ray_coefficient));
-		color = object_raytrace(
-				&program->object, cross_point, program->light_point);
-		add_color_to_image(&program->img, color, x, y);
+		color = object_calc_radiance(program->object[0], cross_point, program->light, program->ambient);
+		add_color_to_image(&program->img, color_to_int(color), x, y);
 	}
 	else
 		add_color_to_image(&program->img, BACKGROUND, x, y);
@@ -70,15 +83,10 @@ int	main(void)
 
 	// mlx setup
 	init_program(&program);
-	init_image(&program, &program.img);
-	// camera setup
-	program.camera_point = init_camera_point();
-	// light setup
-	program.light_point = init_light_point();
-	// object setup
-	sphere_ctor((t_sphere *)&program.object, 1.0, vec_init(0, 0, 5));
 	// create_image
 	create_image(&program);
+	// mlx setup
 	mlx_put_image_to_window(program.mlx, program.win, program.img.image, 0, 0);
 	mlx_loop(program.mlx);
+	return (EXIT_SUCCESS);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -17,7 +17,7 @@ void	init_program(t_program *program)
 	program->camera_point = vec_init(0, 0, -5);
 	// light setup
 	program->light = light(vec_init(-5, 5, -5), color(1.0, 1.0, 1.0));
-	program->ambient = ambient(color(0.1, 0.1, 0.1), color(0.01, 0.01, 0.01));
+	program->ambient = ambient(color(0.1, 0.1, 0.1));
 	// object setup
 	// todo: malloc check, malloc free
 	program->object = malloc(sizeof(t_object *) * OBJECT_NUM);

--- a/src/object.c
+++ b/src/object.c
@@ -4,7 +4,7 @@
 #include "../include/miniRT.h"
 
 static double	object_solve_ray_equation_(t_object *me, t_ray ray);
-static t_color	calc_radiance_(t_object *me, t_vector cross_point, t_light light, t_ambient amb);
+static t_color	calc_radiance_(t_object *me, t_vector cross_point, t_light light, t_color ambient);
 static t_vector	object_calc_normal_(t_object *me, t_vector cross_point);
 
 void	object_ctor(t_object *const me, t_vector center,
@@ -37,10 +37,10 @@ static double	object_solve_ray_equation_(t_object *const me, t_ray ray)
  */
 // normal: 正規化された物体面の法線ベクトル
 // incident_direction: 正規化された入射方向ベクトル
-static t_color	calc_radiance_(t_object *const me, t_vector cross_point, t_light light, t_ambient amb)
+static t_color	calc_radiance_(t_object *const me, t_vector cross_point, t_light light, t_color ambient)
 {
 	t_color			color;
-	const t_color	ra = color_prod(amb.reflection_coefficient, amb.intensity);
+	const t_color	ra = ambient;
 	const t_color	rd = calc_radiance_diffuse(me, cross_point, light);
 	const t_color	rs = calc_radiance_specular(me, cross_point, light);
 	const t_color	radiance = ({

--- a/src/object.c
+++ b/src/object.c
@@ -1,7 +1,6 @@
 #include <assert.h>
 
 #include "../include/object.h"
-#include "../include/miniRT.h"
 
 static double	object_solve_ray_equation_(t_object *me, t_ray ray);
 static t_color	calc_radiance_(t_object *me, t_vector cross_point, t_light light, t_color ambient);
@@ -53,11 +52,7 @@ static t_color	calc_radiance_(t_object *const me, t_vector cross_point, t_light 
 
 static t_vector	object_calc_normal_(t_object *const me, t_vector cross_point)
 {
-	t_vector		vec;
-	const t_vector	normal = ({
-		vec = vec_sub(cross_point, me->center);
-		vec_normalize(vec);
-	});
-
-	return (normal);
+	(void)me;
+	(void)cross_point;
+	assert(0);
 }

--- a/src/object_method.c
+++ b/src/object_method.c
@@ -5,7 +5,7 @@ double	object_solve_ray_equation(t_object *const me, t_ray ray)
 	return ((*me->vptr->solve_ray_equation)(me, ray));
 }
 
-t_color	object_calc_radiance(t_object *me, t_vector cross_point, t_light light, t_ambient amb)
+t_color	object_calc_radiance(t_object *me, t_vector cross_point, t_light light, t_color amb)
 {
 	return ((*me->vptr->calc_radiance)(me, cross_point, light, amb));
 }

--- a/src/object_method.c
+++ b/src/object_method.c
@@ -1,0 +1,16 @@
+#include "../include/object.h"
+
+double	object_solve_ray_equation(t_object *const me, t_ray ray)
+{
+	return ((*me->vptr->solve_ray_equation)(me, ray));
+}
+
+t_color	object_calc_radiance(t_object *me, t_vector cross_point, t_light light, t_ambient amb)
+{
+	return ((*me->vptr->calc_radiance)(me, cross_point, light, amb));
+}
+
+t_vector	object_calc_normal(t_object *me, t_vector cross_point)
+{
+	return ((*me->vptr->calc_normal)(me, cross_point));
+}

--- a/src/object_radiance.c
+++ b/src/object_radiance.c
@@ -1,0 +1,47 @@
+#include <math.h>
+#include "../include/color.h"
+#include "../include/vector.h"
+#include "../include/light.h"
+#include "../include/object.h"
+
+t_color	calc_radiance_diffuse(t_object *obj, t_vector cross_point, t_light light)
+{
+	t_vector		vec;
+	const t_vector	normal = object_calc_normal(obj, cross_point);
+	const t_vector	incident_direction = ({
+		vec = vec_sub(light.coordinate, cross_point);
+		vec_normalize(vec);
+	});
+
+	if (vec_inner_product(normal, incident_direction) >= 0)
+	{
+		return (color_mult(color_prod(obj->diffuse_reflection_coefficient, light.intensity), vec_inner_product(normal, incident_direction)));
+	}
+	else
+		return (color(0, 0, 0));
+}
+
+// specular: 入射光の正反射ベクトル
+t_color	calc_radiance_specular(t_object *obj, t_vector cross_point, t_light light)
+{
+	t_vector		vec;
+	const t_vector	normal = object_calc_normal(obj, cross_point);
+	const t_vector	incident_direction = ({
+		vec = vec_sub(light.coordinate, cross_point);
+		vec_normalize(vec);
+	});
+	const t_vector	specular = ({
+		vec = vec_mult(normal, 2 * vec_inner_product(normal, incident_direction));
+		vec_sub(vec, incident_direction);
+	});
+	const t_vector	cross_point_inverse_normalized = ({
+		vec = vec_mult(cross_point, -1);
+		vec_normalize(vec);
+	});
+
+	if (vec_inner_product(normal, incident_direction) >= 0 && vec_inner_product(vec, specular) >= 0)
+		return (color_mult(color_prod(obj->specular_reflection_coefficient, light.intensity),
+				   pow(vec_inner_product(cross_point_inverse_normalized, specular), SHININESS)));
+	else
+		return (color(0, 0, 0));
+}

--- a/src/sphere.c
+++ b/src/sphere.c
@@ -13,12 +13,13 @@
 
 double		sphere_solve_ray_equation(t_object *me, t_ray ray);
 
-void	sphere_ctor(t_sphere *const me, double radius, t_vector center)
+void	sphere_ctor(t_sphere *const me, double radius, t_vector center,
+			t_color diffuse_reflection_coefficient, t_color specular_reflection_coefficient)
 {
 	static	double
 	(*solve_ray_equation)(t_object *const, t_ray) = &sphere_solve_ray_equation;
 
-	object_ctor(&me->super, center);
+	object_ctor(&me->super, center, diffuse_reflection_coefficient, specular_reflection_coefficient);
 	me->super.vptr->solve_ray_equation = solve_ray_equation;
 	me->radius = radius;
 }

--- a/src/sphere.c
+++ b/src/sphere.c
@@ -11,16 +11,20 @@
 #define POSITIVE 0
 #define NEGATIVE 1
 
-double		sphere_solve_ray_equation(t_object *me, t_ray ray);
+static double	sphere_solve_ray_equation(t_object *me, t_ray ray);
+static t_vector	sphere_calc_normal(t_object *me, t_vector cross_point);
 
 void	sphere_ctor(t_sphere *const me, double radius, t_vector center,
 			t_color diffuse_reflection_coefficient, t_color specular_reflection_coefficient)
 {
 	static	double
 	(*solve_ray_equation)(t_object *const, t_ray) = &sphere_solve_ray_equation;
+	static	t_vector
+	(*calc_normal)(t_object *const, t_vector) = &sphere_calc_normal;
 
 	object_ctor(&me->super, center, diffuse_reflection_coefficient, specular_reflection_coefficient);
 	me->super.vptr->solve_ray_equation = solve_ray_equation;
+	me->super.vptr->calc_normal = calc_normal;
 	me->radius = radius;
 }
 
@@ -41,7 +45,7 @@ void	sphere_ctor(t_sphere *const me, double radius, t_vector center,
  * C = magnitude(camera_vector) ^ 2 + magnitude(sphere_center_vector) ^ 2
  * 		- 2 * (inner_product(camera_vector, sphere_center_vector)
  */
-double	sphere_solve_ray_equation(t_object *const me_, t_ray ray)
+static double	sphere_solve_ray_equation(t_object *const me_, t_ray ray)
 {
 	const t_sphere	*me = (t_sphere *)me_;
 	const double	abc[3] = {
@@ -67,4 +71,15 @@ double	sphere_solve_ray_equation(t_object *const me_, t_ray ray)
 		return (t[POSITIVE]);
 	else
 		return (min(t[POSITIVE], t[NEGATIVE]));
+}
+
+static t_vector	sphere_calc_normal(t_object *const me, t_vector cross_point)
+{
+	t_vector		vec;
+	const t_vector	normal = ({
+		vec = vec_sub(cross_point, me->center);
+		vec_normalize(vec);
+	});
+
+	return (normal);
 }


### PR DESCRIPTION
## 実装内容
<!--
どういう実装にしたか
 -->
![スクリーンショット 2022-05-10 16 02 54](https://user-images.githubusercontent.com/69781798/167568014-10e4003a-546c-4415-bd3c-eefdf4c41b9b.png)

- [このページ](https://knzw.tech/raytracing/?page_id=1301)の課題2-4
- `color.c`RGBチャンネル対応し、汎用関数の提供
- `t_object`に法線ベクトルを求めるメソッドを追加。これで平面にも簡単に対応できると思われる！（Thanks）
- Normの`LINE TOO LONG`をPRの段階で直すのは少し無駄な気がしてきたので、それを見ないように変更
- 光のパラメータをrtファイルから読み取って動的に変更できるように構造体へ移動 (`light.h` `miniRT.h`)
- radianceを求めるロジックは変わっておらず、法線ベクトルのところとRGBチャンネルの計算だけ変わった（normに対応しようとすると、変更と同時に関数のファイル間移動が起きてしまうから、良くないかも...）
- `main.c`の `init_program()` で基本的なパラメタを設定できるようにした。この中で、rtファイルを読むイメージ？

## レビュー観点
<!--
どういった箇所を中心にレビューして欲しいか
 -->
- object周りの変更
- 計算がバグってないか...

## 変更の種類
・新機能
・リファクタリング
<!--
・バグ修正
・ドキュメント作成・更新
・その他
 -->
<!-- ## テスト
・パラメータ（バグが起こったもの、新しく追加したもの等）
・環境
など、必要に応じて書く
 -->

## メモ
- rtファイルで指定できる要素とこの電気大学の資料で設定できるパラメタに乖離がありそう。そこらへんの相談したい！あと、ボーナスどのくらいやるか？（ライト複数対応と色とかは簡単そう）

## レビュー優先度
3. 今日〜明日中で見てもらいたい 🚶
