### PR TITLE
鏡面反射の計算を修正🚗

### DIFF
--- a/src/object_radiance.c
+++ b/src/object_radiance.c
@@ -48,7 +48,7 @@ t_color	calc_radiance_specular(t_object *obj, t_vector cross_point, t_light ligh
 		vec_sub(vec, incident_direction);
 	});
 	const t_vector	cross_point_inverse_normalized = ({
-		vec = vec_mult(cross_point, -1);
+		vec = vec_mult(camera2cross, -1);
 		vec_normalize(vec);
 	});
 

--- a/src/rt_params_obj.c
+++ b/src/rt_params_obj.c
@@ -15,7 +15,8 @@ char	*load_sphere(t_program *p, char **info)
 	radius /= 2;
 	if (!(get_color_from_str(info[2], &col) && check_color_range(col, 0.0, 255.0)))
 		return (ERR_MISCONFIGURED_SPHERE);
-	sphere_ctor(get(sp, 0), radius, center, color_mult(col, (double)1/255), color(0, 0, 0));
+//	sphere_ctor(get(sp, 0), radius, center, color_mult(col, (double)1/255), color(0, 0, 0));
+	sphere_ctor(get(sp, 0), radius, center, color_mult(col, (double)1/255), color(0.8, 0.8, 0.8));
 	append(p->objects, &sp);
 	return (NO_ERR);
 }
@@ -40,7 +41,8 @@ char	*load_plane(t_program *p, char **info)
 	}
 	if (!(get_color_from_str(info[2], &col) && check_color_range(col, 0.0, 255.0)))
 		return (ERR_MISCONFIGURED_PLANE);
-	plane_ctor(get(pl, 0), center, normal, color_mult(col, (double)1/255), color(0, 0, 0));
+//	plane_ctor(get(pl, 0), center, normal, color_mult(col, (double)1/255), color(0, 0, 0));
+	plane_ctor(get(pl, 0), center, normal, color_mult(col, (double)1/255), color(0.8, 0.8, 0.8));
 	append(p->objects, &pl);
 	return (NO_ERR);
 }
@@ -71,7 +73,8 @@ char	*load_cylinder(t_program *p, char **info)
 		return (ERR_MISCONFIGURED_CYLINDER);
 	if (!(get_color_from_str(info[4], &col) && check_color_range(col, 0.0, 255.0)))
 		return (ERR_MISCONFIGURED_CYLINDER);
-	cylinder_ctor(get(cy, 0), center, normal, radius, height, color_mult(col, (double)1/255), color(0, 0, 0));
+//	cylinder_ctor(get(cy, 0), center, normal, radius, height, color_mult(col, (double)1/255), color(0, 0, 0));
+	cylinder_ctor(get(cy, 0), center, normal, radius, height, color_mult(col, (double)1/255), color(0.8, 0.8, 0.8));
 	append(p->objects, &cy);
 	return (NO_ERR);
 }


### PR DESCRIPTION
## 実装内容
<!--
どういう実装にしたか
 -->
参考: #40 

- 鏡面反射の計算はしていなかったが、デフォルト値を設定するようにした。計算がそもそも間違っていたので、そこを変更。（視線から交差点へのベクトルの逆ベクトルをとるところを、原点から交差点への逆ベクトルを取ってしまっていた。以前のPRでうまく行っていたのは、カメラと原点が同じ直線上にあったからかと）

変更前
![スクリーンショット 2022-05-13 14 56 30](https://user-images.githubusercontent.com/69781798/168220218-3cfb4545-3442-4c69-ba7c-178f8a1555ab.png)

変更後
![スクリーンショット 2022-05-13 14 56 09](https://user-images.githubusercontent.com/69781798/168220170-9a1f74d1-db86-4d0c-a464-819579d16d9e.png)


## レビュー観点
・バグ修正
<!--
どういった箇所を中心にレビューして欲しいか
 -->

## 変更の種類
<!--
・新機能
・リファクタリング
・ドキュメント作成・更新
・その他
 -->
## テスト
<!-- 
・パラメータ（バグが起こったもの、新しく追加したもの等）
・環境
など、必要に応じて書く
 -->
```
./miniRT scenes/kohkubo/1.rt
./miniRT scenes/kohkubo/10.rt
./miniRT scenes/kohkubo/11-0.rt
```

## メモ
鏡面反射係数をどういう風にrtファイルから受け取るのかは議論したい！

## レビュー優先度
1. すぐに見てもらいたい（hotfixなど） 🚀
2. 今日中に見てもらいたい 🚗
3. 今日〜明日中で見てもらいたい 🚶
4. 数日以内で見てもらいたい 🐢
