### PR TITLE
オブジェクトの中ではなく、描画する部分とカメラの位置が重なった時🚗

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -103,8 +103,8 @@ void	draw(t_program *p, int x, int y)
 	t_color		color;
 
 	screen_point = init_screen_point(p->camera, x, y);
-	ray.start = p->camera.pos;
 	ray.direction = vec_sub(screen_point, p->camera.pos);
+	ray.start = vec_add(p->camera.pos, vec_mult(ray.direction, EPSILON));
 	obj_index = closest_object(p->objects, ray, INFINITY, false);
 	if (obj_index >= 0)
 	{


### PR DESCRIPTION
## 実装内容
<!--
どういう実装にしたか
 -->
- オブジェクトに厚みが無い？と考え、微小な値をスクリーン方向にプラスすることで解決。（ユーザー体験的にも、カメラを移動できるとして、オブジェクトに重なるときに一瞬全て同じ色になるのは微妙そう）

変更前
![スクリーンショット 2022-05-13 15 52 06](https://user-images.githubusercontent.com/69781798/168227593-8230b335-68ed-4bb0-9f48-e483c376a00f.png)


変更後
![スクリーンショット 2022-05-13 15 51 14](https://user-images.githubusercontent.com/69781798/168227464-10a96c42-d8e8-486d-ae95-70c8f32c0bdc.png)


## レビュー観点
<!--
どういった箇所を中心にレビューして欲しいか
 -->
- この方針でOK?

## 変更の種類
・バグ修正
<!--
・新機能
・リファクタリング
・ドキュメント作成・更新
・その他
 -->

## テスト
```
./miniRT scenes/kohkubo/13-1.rt
./miniRT scenes/kohkubo/13-2.rt
```

<!-- 
・パラメータ（バグが起こったもの、新しく追加したもの等）
・環境
など、必要に応じて書く
 -->

## メモ

## レビュー優先度
1. すぐに見てもらいたい（hotfixなど） 🚀
2. 今日中に見てもらいたい 🚗
3. 今日〜明日中で見てもらいたい 🚶
4. 数日以内で見てもらいたい 🐢
