### PR TITLE
バンプマップメソッド周りのリファクタリング・細かい修正🚶

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 NAME	= miniRT
 CC		= gcc
-CFLAGS	= -Werror -Wall -Wextra $(INC) -g -fsanitize=thread
+# CFLAGS	= -Werror -Wall -Wextra $(INC) -g -fsanitize=thread
+CFLAGS	= -Werror -Wall -Wextra $(INC) -g -fsanitize=address
 
 SRC_PATH = src
 UTILS_PATH = utils

--- a/include/obj_info.h
+++ b/include/obj_info.h
@@ -28,6 +28,7 @@ typedef struct s_uv {
 t_color ch_pattern_at(const t_obj_info *info, t_uv uv);
 
 t_vector	get_vector_from_normal_map(double u, double v, const t_obj_info *info);
+// t_vector	get_vector_from_normal_map(t_uv uv, t_img *bm, int freq_u, int freq_v);
 t_vector	tangent_to_model(t_vector tangent, t_vector t, t_vector b, t_vector n);
 
 #endif

--- a/include/object.h
+++ b/include/object.h
@@ -25,6 +25,7 @@ void		object_ctor(t_object *me, t_vector center, t_color diffuse_reflection_coef
 double		object_solve_ray_equation(t_object *me, t_ray ray);
 t_color		object_calc_radiance(t_object *me, t_vector cross_point, t_light light, t_vector camera_dir);
 t_vector	object_calc_normal(t_object *me, t_vector cross_point);
+t_vector	object_calc_bumpmap_normal(t_object *me, t_vector cross_point);
 t_color		object_calc_color(t_object *me, t_vector cross_point);
 
 // Virtual table
@@ -32,6 +33,7 @@ struct s_object_vtbl {
 	double		(*solve_ray_equation)(t_object *const me, t_ray);
 	t_color		(*calc_radiance)(t_object * const me, t_vector, t_light, t_vector);
 	t_vector	(*calc_normal)(t_object * const me, t_vector);
+	t_vector	(*calc_bumpmap_normal)(t_object * const me, t_vector);
 	t_color		(*calc_color)(t_object * const me, t_vector cross_point);
 };
 

--- a/scenes/bumpmap.rt
+++ b/scenes/bumpmap.rt
@@ -9,12 +9,12 @@ C  0,3,-5    0,-0.3,1    45
 # C  0,10,0    0,-1,0    45
 pl 0,-1,0   0,1,0       176,176,176
 bm images/tacomeat.xpm  1 1
-sp -2,0,2 2 255,0,0
-bm images/tacomeat.xpm  4 2
+sp -2,0,2 2 0,0,255
+bm images/geo.xpm  1 1
 # bm images/ripple.xpm  4 2
-cy 2,-1,3 0,1,0 2.0 2.0 176,0.0,0.0
+cy 2,-1,3 0,1,1 2.0 2.0 0,255,0
 bm images/tacomeat.xpm  4 2
 # bm images/ripple.xpm  1 1
 co 0,3,10   0.2,-1,0    40    255,0,0
-bm images/tacomeat.xpm  2 1
-# bm images/ripple.xpm  3 1
+bm images/ripple.xpm  3 1
+# bm images/tacomeat.xpm  2 1

--- a/src/bumpmap.c
+++ b/src/bumpmap.c
@@ -14,6 +14,7 @@ static t_vector		convert_color_to_vector(t_color c)
 	return (rtn);
 }
 
+<<<<<<< HEAD
 static double	rt_fmod(double x, double y)
 {
 	if (x >= 0)
@@ -31,7 +32,6 @@ t_vector	get_vector_from_normal_map(double u, double v, const t_obj_info *info)
 
 			t_color	c = get_color_from_image(&info->bm_image, (int)i, (int)j);
 			c = color_add(color_mult(c, 2), color(-1, -1, -1));
-
 			n = convert_color_to_vector(c);
 			n;
 	});
@@ -39,12 +39,20 @@ t_vector	get_vector_from_normal_map(double u, double v, const t_obj_info *info)
 	return (normal);
 }
 
+// t_vector	get_vector_from_normal_map(t_uv uv, t_img *bm, int freq_u, int freq_v)
+// {
+// 	const t_vector	normal = ({
+// 			t_vector		n;
+// 			const double	i = fmod(uv.v * freq_v, 1.0) * bm->height;
+// 			const double	j = fmod(uv.u * freq_u, 1.0) * bm->width;
+
+// 			t_color	c = get_color_from_image(bm, (int)j, (int)i);
+
 t_vector	tangent_to_model(t_vector tangent, t_vector t, t_vector b, t_vector n)
 {
 	const t_vector	normal = ({
 			t_vector	res;
 
-			// 資料とy, z軸が逆！
 			res = vec_add(vec_add(
 				vec_mult(t, tangent.x),
 				vec_mult(b, tangent.z)),

--- a/src/bumpmap.c
+++ b/src/bumpmap.c
@@ -14,39 +14,19 @@ static t_vector		convert_color_to_vector(t_color c)
 	return (rtn);
 }
 
-<<<<<<< HEAD
-static double	rt_fmod(double x, double y)
-{
-	if (x >= 0)
-		return (fmod(x, y));
-	else
-		return (y - fmod(-x, y));
-}
-
 t_vector	get_vector_from_normal_map(double u, double v, const t_obj_info *info)
 {
-	const t_vector	normal = ({
-			t_vector		n;
-			const double	i = rt_fmod(u * info->bm_image.height * info->bm_freq_u, info->bm_image.height);
-			const double	j = rt_fmod(v * info->bm_image.width * info->bm_freq_v, info->bm_image.height);
+	const t_vector	tangent = ({
+			const double	j = fmod(u * info->bm_freq_u, 1.0) * info->bm_image.width;
+			const double	i = fmod(v * info->bm_freq_v, 1.0) * info->bm_image.height;
 
-			t_color	c = get_color_from_image(&info->bm_image, (int)i, (int)j);
+			t_color	c = get_color_from_image(&info->bm_image, (int)j, (int)i);
 			c = color_add(color_mult(c, 2), color(-1, -1, -1));
-			n = convert_color_to_vector(c);
-			n;
+			convert_color_to_vector(c);
 	});
 
-	return (normal);
+	return (tangent);
 }
-
-// t_vector	get_vector_from_normal_map(t_uv uv, t_img *bm, int freq_u, int freq_v)
-// {
-// 	const t_vector	normal = ({
-// 			t_vector		n;
-// 			const double	i = fmod(uv.v * freq_v, 1.0) * bm->height;
-// 			const double	j = fmod(uv.u * freq_u, 1.0) * bm->width;
-
-// 			t_color	c = get_color_from_image(bm, (int)j, (int)i);
 
 t_vector	tangent_to_model(t_vector tangent, t_vector t, t_vector b, t_vector n)
 {

--- a/src/cone.c
+++ b/src/cone.c
@@ -105,8 +105,9 @@ static t_vector	cone_calc_bumpmap_normal(t_object *const me_, t_vector cross_poi
 {
 	const t_cone	*me = (t_cone *)me_;
 	const t_vector	normal = ({
-			t_vector		m;
-			const t_uv		uv = calc_uv(me, cross_point);
+			t_uv			uv = calc_uv(me, cross_point);
+			if (uv.v < 0)
+				uv.v *= -1;
 			const t_vector	tangent = get_vector_from_normal_map(uv.u, uv.v, &me->super.info);
 
 			t_vector		direction = me->normal;
@@ -117,8 +118,7 @@ static t_vector	cone_calc_bumpmap_normal(t_object *const me_, t_vector cross_poi
 			const t_vector	t = vec_normalize(vec_cross(direction, n));
 			const t_vector	b = vec_normalize(vec_cross(t, n));
 
-			m = tangent_to_model(tangent, t, b, n);
-			m;
+			tangent_to_model(tangent, t, b, n);
 	});
 
 	return (normal);

--- a/src/cylinder.c
+++ b/src/cylinder.c
@@ -6,6 +6,7 @@
 
 static double	cylinder_solve_ray_equation(t_object *me, t_ray ray);
 static t_vector	cylinder_calc_normal(t_object *me, t_vector cross_point);
+static t_vector	cylinder_calc_bumpmap_normal(t_object *me, t_vector cross_point);
 static t_color	cylinder_calc_color(t_object *me, t_vector cross_point);
 static t_uv 	calc_uv(const t_cylinder *const me, t_vector cross_point);
 
@@ -22,6 +23,7 @@ void	cylinder_ctor(
 			.solve_ray_equation = &cylinder_solve_ray_equation,
 			.calc_radiance = &calc_radiance_,
 			.calc_normal = &cylinder_calc_normal,
+			.calc_bumpmap_normal = &cylinder_calc_bumpmap_normal,
 			.calc_color = &cylinder_calc_color,
 	};
 	const t_vector			e1 = ({
@@ -98,20 +100,26 @@ t_vector	cylinder_calc_normal(t_object *const me_, t_vector cross_point)
 
 		m = vec_sub(center_to_cross, vec_mult(me->normal, h));
 		m = vec_normalize(m);
-
-		if (me->super.info.flag & 1 << FLAG_BUMPMAP)
-		{
-			const t_uv	uv = calc_uv(me, cross_point);
-			const t_vector	tangent = get_vector_from_normal_map(1 - uv.u, 1 - uv.v, &me->super.info);
-
-			const t_vector	n = m;
-			const t_vector	b = me->normal;
-			const t_vector	t = vec_cross(b, n);
-
-			m = tangent_to_model(tangent, t, b, n);
-		}
-
 		m;
+	});
+
+	return (normal);
+}
+
+t_vector	cylinder_calc_bumpmap_normal(t_object *const me_, t_vector cross_point)
+{
+	const t_cylinder	*me = (t_cylinder *)me_;
+	const t_vector		normal = ({
+		t_uv			uv = calc_uv(me, cross_point);
+		uv.u = 1 - uv.u;
+		uv.v = 1 - uv.v;
+		const t_vector	tangent = get_vector_from_normal_map(uv.u, uv.v, &me->super.info);
+
+		const t_vector	n = object_calc_bumpmap_normal(me_, cross_point);
+		const t_vector	b = me->normal;
+		const t_vector	t = vec_cross(b, n);
+
+		tangent_to_model(tangent, t, b, n);
 	});
 
 	return (normal);

--- a/src/cylinder.c
+++ b/src/cylinder.c
@@ -110,12 +110,10 @@ t_vector	cylinder_calc_bumpmap_normal(t_object *const me_, t_vector cross_point)
 {
 	const t_cylinder	*me = (t_cylinder *)me_;
 	const t_vector		normal = ({
-		t_uv			uv = calc_uv(me, cross_point);
-		uv.u = 1 - uv.u;
-		uv.v = 1 - uv.v;
-		const t_vector	tangent = get_vector_from_normal_map(uv.u, uv.v, &me->super.info);
+		const t_uv		uv = calc_uv(me, cross_point);
+		const t_vector	tangent = get_vector_from_normal_map(1 - uv.u, 1 - uv.v, &me->super.info);
 
-		const t_vector	n = object_calc_bumpmap_normal(me_, cross_point);
+		const t_vector	n = object_calc_normal(me_, cross_point);
 		const t_vector	b = me->normal;
 		const t_vector	t = vec_cross(b, n);
 

--- a/src/object.c
+++ b/src/object.c
@@ -5,6 +5,7 @@
 
 static double	object_solve_ray_equation_(t_object *me, t_ray ray);
 static t_vector	object_calc_normal_(t_object *me, t_vector cross_point);
+static t_vector	object_calc_bumpmap_normal_(t_object *me, t_vector cross_point);
 static t_color	calc_color_(t_object *me, t_vector cross_point);
 
 void	object_ctor(t_object *const me, t_vector center,
@@ -14,6 +15,7 @@ void	object_ctor(t_object *const me, t_vector center,
 			.solve_ray_equation = &object_solve_ray_equation_,
 			.calc_radiance = &calc_radiance_,
 			.calc_normal = &object_calc_normal_,
+			.calc_bumpmap_normal = &object_calc_bumpmap_normal_,
 			.calc_color = &calc_color_,
 	};
 	const t_obj_info	info = {
@@ -54,6 +56,13 @@ t_color	calc_radiance_(t_object *const me, t_vector cross_point, t_light light, 
 }
 
 static t_vector	object_calc_normal_(t_object *const me, t_vector cross_point)
+{
+	(void)me;
+	(void)cross_point;
+	assert(0);
+}
+
+static t_vector	object_calc_bumpmap_normal_(t_object *const me, t_vector cross_point)
 {
 	(void)me;
 	(void)cross_point;

--- a/src/object_method.c
+++ b/src/object_method.c
@@ -15,6 +15,11 @@ t_vector	object_calc_normal(t_object *me, t_vector cross_point)
 	return ((*me->vptr->calc_normal)(me, cross_point));
 }
 
+t_vector	object_calc_bumpmap_normal(t_object *me, t_vector cross_point)
+{
+	return ((*me->vptr->calc_bumpmap_normal)(me, cross_point));
+}
+
 t_color	object_calc_color(t_object *me, t_vector cross_point)
 {
 	return ((*me->vptr->calc_color)(me, cross_point));

--- a/src/object_radiance.c
+++ b/src/object_radiance.c
@@ -9,10 +9,14 @@ t_color	calc_radiance_diffuse(t_object *obj, t_vector cross_point, t_light light
 {
 	t_vector		vec;
 	const t_vector	normal = ({
-			t_vector n = object_calc_normal(obj, cross_point);
-			if (vec_dot(n, camera2cross) > 0)
-				n = vec_mult(n, -1);
-			n;
+		t_vector n;
+		if (obj->info.flag & (1 << FLAG_BUMPMAP))
+			n = object_calc_bumpmap_normal(obj, cross_point);
+		else
+			n = object_calc_normal(obj, cross_point);
+		if (vec_dot(n, camera2cross) > 0)
+			n = vec_mult(n, -1);
+		n;
 	});
 	const t_vector	incident_direction = ({
 		vec = vec_sub(light.pos, cross_point);
@@ -32,7 +36,11 @@ t_color	calc_radiance_specular(t_object *obj, t_vector cross_point, t_light ligh
 {
 	t_vector		vec;
 	const t_vector	normal = ({
-		t_vector n = object_calc_normal(obj, cross_point);
+		t_vector n;
+		if (obj->info.flag & (1 << FLAG_BUMPMAP))
+			n = object_calc_bumpmap_normal(obj, cross_point);
+		else
+			n = object_calc_normal(obj, cross_point);
 		if (vec_dot(n, camera2cross) > 0)
 			n = vec_mult(n, -1);
 		n;

--- a/src/sphere.c
+++ b/src/sphere.c
@@ -94,9 +94,8 @@ static t_vector	sphere_calc_bumpmap_normal(t_object *const me_, t_vector cross_p
 {
 	const t_sphere	*me = (t_sphere *)me_;
 	const t_vector	normal = ({
-		t_uv		uv = calc_uv(me, cross_point);
-		uv.v = 1 - uv.v;
-		const t_vector	tangent = get_vector_from_normal_map(uv.u, uv.v, &me->super.info);
+		const t_uv		uv = calc_uv(me, cross_point);
+		const t_vector	tangent = get_vector_from_normal_map(uv.u, 1 - uv.v, &me->super.info);
 
 		const t_vector	n = object_calc_normal(me_, cross_point);
 		t_vector		t;

--- a/src/sphere.c
+++ b/src/sphere.c
@@ -121,7 +121,7 @@ static t_color	sphere_calc_color(t_object *const me_, t_vector cross_point)
 		if (me->super.info.flag & 1 << FLAG_CHECKER)
 			c = ch_pattern_at(&me->super.info, calc_uv(me, cross_point));
 		else
-			c = me->super.material.k_specular;
+			c = me->super.material.k_diffuse;
 		c;
 	});
 

--- a/utils/ft_strtod.c
+++ b/utils/ft_strtod.c
@@ -7,6 +7,7 @@ bool	ft_strtod(const char *s, double *val)
 	int		fract;
 
 	sign = 1.0;
+	converted = 0.0;
 	while (ft_isspace(*s))
 		s++;
 	if ((*s == '+' || *s == '-') && *s++ == '-')


### PR DESCRIPTION
## 実装内容
<!--
どういう実装にしたか
 -->
#61 参照

### オブジェクトのメソッド分離
- 以前は、各オブジェクトの持つ`calc_normal`メソッドの中に、バンプマップの法線ベクトルの計算を行うロジックを入れていた。
- しかし、あくまで`calc_normal`は通常の物体の法線ベクトルを返す、というメソッドとして役割分離した方が、設計的にも拡張性の観点から見ても良いという結論に至った。
- そのため、`calc_bumpmap_normal`という新しいメソッドをオブジェクトに追加し、どちらのメソッドを呼び出すかは呼び出し側（今回だと`calc_radiance_***()`）で条件分岐するようにした。
![スクリーンショット 2022-05-19 17 50 04](https://user-images.githubusercontent.com/34294957/169253427-a8f36519-4110-409b-8bc0-d0fd8658e160.png)

### その他
- `get_vector_from_normal_map`における`u, v`を用いた座標計算を修正
- `sphere`の拡散反射係数が鏡面反射係数になっていたのを修正
- `ft_strtod`の`converted`を初期化！！！

## レビュー観点
<!--
どういった箇所を中心にレビューして欲しいか
 -->
- メソッドの分離
- 各種計算方法や関数の修正箇所

## 変更の種類
<!--
・新機能
・バグ修正
・リファクタリング
・ドキュメント作成・更新
・その他
 -->
- リファクタリング
- バグ修正

<!-- ## テスト
・パラメータ（バグが起こったもの、新しく追加したもの等）
・環境
など、必要に応じて書く
 -->

## メモ
変数の初期化は大事だね！！！！！（すみません！！！！）

## レビュー優先度
1. すぐに見てもらいたい（hotfixなど） 🚀
2. 今日中に見てもらいたい 🚗
3. 今日〜明日中で見てもらいたい 🚶
4. 数日以内で見てもらいたい 🐢
