### PR TITLE
color周りの余分な関数削除+uvがマイナスの時の処理追加

### DIFF
--- a/include/color.h
+++ b/include/color.h
@@ -14,7 +14,6 @@ typedef struct s_color {
 }	t_color;
 
 // color.c
-int		color_to_int(t_color color);
 t_color	color(double r, double g, double b);
 t_color	color_add(t_color c1, t_color c2);
 t_color	color_mult(t_color c, double k);

--- a/include/miniRT.h
+++ b/include/miniRT.h
@@ -31,7 +31,7 @@ typedef struct s_program {
 // todo: create its header file when there are more funcs
 // image.c
 void		init_image(t_program *program, t_img *img);
-void		add_color_to_image(t_img *img, int color, int x, int y);
+void		add_color_to_image(t_img *img, t_color color, int x, int y);
 t_color		get_color_from_image(const t_img *img, int x, int y);
 
 // utils.c

--- a/src/color.c
+++ b/src/color.c
@@ -1,16 +1,5 @@
 #include "../include/color.h"
 
-int	color_to_int(t_color color)
-{
-	int	rtn;
-
-	rtn = 0;
-	rtn |= (int)(color.b * 255);
-	rtn |= (int)(color.g * 255) << 8;
-	rtn |= (int)(color.r * 255) << 16;
-	return (rtn);
-}
-
 t_color	color(double r, double g, double b)
 {
 	t_color	rtn;

--- a/src/color_utils.c
+++ b/src/color_utils.c
@@ -29,11 +29,3 @@ bool	check_color_range(t_color c, double min, double max)
 
 	return (r_ok && g_ok && b_ok);
 }
-
-t_color	color_map(t_color c)
-{
-	c.r = min(1, c.r);
-	c.g = min(1, c.g);
-	c.b = min(1, c.b);
-	return (c);
-}

--- a/src/cone.c
+++ b/src/cone.c
@@ -106,8 +106,6 @@ static t_vector	cone_calc_bumpmap_normal(t_object *const me_, t_vector cross_poi
 	const t_cone	*me = (t_cone *)me_;
 	const t_vector	normal = ({
 			t_uv			uv = calc_uv(me, cross_point);
-			if (uv.v < 0)
-				uv.v *= -1;
 			const t_vector	tangent = get_vector_from_normal_map(uv.u, uv.v, &me->super.info);
 
 			t_vector		direction = me->normal;
@@ -153,6 +151,8 @@ static t_uv 	calc_uv(const t_cone *const me, t_vector cross_point)
 		// 方位角 (-pi < phi <= pi)
 		const double phi = atan2(n1, n2);
 		uv.u = phi / (2 * M_PI) + 0.5;
+		if (uv.v < 0)
+			uv.v *= -1;
 		uv;
 	});
 

--- a/src/image.c
+++ b/src/image.c
@@ -1,4 +1,5 @@
 #include "../include/miniRT.h"
+#include "../include/math.h"
 #include "../minilibx-linux/mlx.h"
 
 void	init_image(t_program *program, t_img *img)
@@ -8,14 +9,16 @@ void	init_image(t_program *program, t_img *img)
 			&img->bits_per_pixel, &img->size_line, &img->endian);
 }
 
-void	add_color_to_image(t_img *img, int color, int x, int y)
+void	add_color_to_image(t_img *img, t_color color, int x, int y)
 {
 	const int	pixel = (y * img->size_line) + (x * 4);
 
-	img->buffer[pixel + 0] = (char)(color & 0xFF);
-	img->buffer[pixel + 1] = (char)((color >> 8) & 0xFF);
-	img->buffer[pixel + 2] = (char)((color >> 16) & 0xFF);
-	img->buffer[pixel + 3] = (char)(color >> 24);
+	color.r = min(1, color.r);
+	color.g = min(1, color.g);
+	color.b = min(1, color.b);
+	img->buffer[pixel + 0] = (char)(color.b * 255);
+	img->buffer[pixel + 1] = (char)(color.g * 255);
+	img->buffer[pixel + 2] = (char)(color.r * 255);
 }
 
 t_color	get_color_from_image(const t_img *img, int x, int y)

--- a/src/main.c
+++ b/src/main.c
@@ -8,7 +8,11 @@
 #include "../include/math.h"
 #include "../include/mlx_hooks.h"
 
-#define BACKGROUND 0x6495ED
+const static t_color g_col_background = {
+		.r = 0.392157,
+		.g = 0.584314,
+		.b = 0.929412,
+};
 
 void	init_program(t_program *program)
 {
@@ -112,11 +116,10 @@ void	draw(t_program *p, int x, int y)
 	{
 		cross_point = vec_add(ray.start, vec_mult(ray.direction, object_solve_ray_equation(get_x2(p->objects, obj_index, 0), ray)));
 		color = handle_lights(p, obj_index, cross_point);
-		color = color_map(color);
-		add_color_to_image(&p->img, color_to_int(color), x, y);
+		add_color_to_image(&p->img, color, x, y);
 	}
 	else
-		add_color_to_image(&p->img, BACKGROUND, x, y);
+		add_color_to_image(&p->img, g_col_background, x, y);
 }
 
 // screen_point described as 'pw'

--- a/src/plane.c
+++ b/src/plane.c
@@ -71,10 +71,6 @@ static t_vector	plane_calc_bumpmap_normal(t_object *const me_, t_vector cross_po
 {
 	const t_plane	*me = (t_plane *)me_;
 	t_uv 		uv = calc_uv(me, cross_point);
-	if (uv.u < 0)
-		uv.u = 1 + uv.u;
-	if (uv.v < 0)
-		uv.v = 1 + uv.v;
 	const t_vector	tangent = get_vector_from_normal_map(uv.u, uv.v, &me->super.info);
 	const t_vector	normal = tangent_to_model(tangent, me->eu, me->ev, object_calc_normal(me_, cross_point));
 
@@ -103,5 +99,9 @@ static t_uv 	calc_uv(const t_plane *const me, t_vector cross_point)
 
 	uv.u = modf(vec_dot(vec_sub(cross_point, me->super.center), me->eu), &integer);
 	uv.v = modf(vec_dot(vec_sub(cross_point, me->super.center), me->ev), &integer);
+	if (uv.u < 0)
+		uv.u = 1 + uv.u;
+	if (uv.v < 0)
+		uv.v = 1 + uv.v;
 	return (uv);
 }


### PR DESCRIPTION
## 実装内容
<!--
どういう実装にしたか
 -->
- color周りの余分な関数削除 (color_to_intとcolor_map)
- calc_uv()でuvがマイナスの時の処理を行うように変更

## レビュー観点
<!--
どういった箇所を中心にレビューして欲しいか
 -->
-変更が問題ないか

## 変更の種類
・リファクタリング
<!--
・新機能
・バグ修正
・ドキュメント作成・更新
・その他
 -->
<!-- ## テスト
・パラメータ（バグが起こったもの、新しく追加したもの等）
・環境
など、必要に応じて書く
 -->

## メモ

## レビュー優先度
1. すぐに見てもらいたい（hotfixなど） 🚀
2. 今日中に見てもらいたい 🚗
3. 今日〜明日中で見てもらいたい 🚶
4. 数日以内で見てもらいたい 🐢
