### PR TITLE
簡単なNorm対応🐢

### DIFF
--- a/include/scene.h
+++ b/include/scene.h
@@ -52,6 +52,9 @@
 // scene.c
 void	load_rt_file(int argc, char **argv, t_program *program);
 
+// read_rt_file.c
+char	*read_rt_file(char *filename, t_program *p);
+
 // rt_params.c
 char	*load_ambient(t_program *p, char **info);
 char	*load_camera(t_program *p, char **info);

--- a/include/scene.h
+++ b/include/scene.h
@@ -34,15 +34,15 @@
 # define ERR_MISCONFIGURED_PLANE "Plane is misconfigured"
 # define ERR_MISCONFIGURED_CYLINDER "Cylinder is misconfigured"
 # define ERR_MISCONFIGURED_SPOTLIGHT "Spotlight is misconfigured"
-# define ERR_DUPLICATE_CAPITAL_IDENTIFIER "Capitalized identifiers are duplicated"
-# define ERR_LACK_CAPITAL_IDENTIFIER "Capitalized identifiers are lack"
+# define ERR_DUPLICATE_IDENTIFIER "Capitalized identifiers are duplicated"
+# define ERR_LACK_IDENTIFIER "Capitalized identifiers are lack"
 # define ERR_MISCONFIGURED_CONE "Cone is misconfigured"
 # define ERR_UNDEFINED_IDENTIFIER "Undefined identifier exists"
 # define ERR_UNRESOLVED_MATERIAL "Material is specified before any object"
 # define ERR_MISCONFIGURED_CHECKER "Checker is misconfigured"
 # define ERR_MISCONFIGURED_BUMPMAP "Bumpmap is misconfigured"
 # define ERR_MISCONFIGURED_TEXTURE "Texture is misconfigured"
-# define ERR_DUPLICATE_MATERIAL "Same material parameters specified for same object"
+# define ERR_DUPLICATE_MATERIAL "Material parameter has already been specified."
 
 // Warning messages
 # define WARNING_NOT_NORMALIZED YELLOW"Not normalized vector found (We normalized it for you!)"RESET

--- a/src/bumpmap.c
+++ b/src/bumpmap.c
@@ -4,7 +4,7 @@
 #include "../include/material.h"
 #include "../minilibx-linux/mlx.h"
 
-static t_vector		convert_color_to_vector(t_color c)
+static t_vector	convert_color_to_vector(t_color c)
 {
 	t_vector	rtn;
 
@@ -14,11 +14,16 @@ static t_vector		convert_color_to_vector(t_color c)
 	return (rtn);
 }
 
-t_vector	get_vector_from_normal_map(double u, double v, const t_obj_info *info)
+t_vector	get_vector_from_normal_map(
+	double u,
+	double v,
+	const t_obj_info *info)
 {
 	const t_vector	tangent = ({
-			const double	x = fmod(u * info->bm_freq_u, 1.0) * info->bm_image.width;
-			const double	y = fmod(v * info->bm_freq_v, 1.0) * info->bm_image.height;
+			const double	x =
+				fmod(u * info->bm_freq_u, 1.0) * info->bm_image.width;
+			const double	y =
+				fmod(v * info->bm_freq_v, 1.0) * info->bm_image.height;
 
 			t_color	c = get_color_from_image(&info->bm_image, (int)x, (int)y);
 			c = color_add(color_mult(c, 2), color(-1, -1, -1));
@@ -28,7 +33,11 @@ t_vector	get_vector_from_normal_map(double u, double v, const t_obj_info *info)
 	return (tangent);
 }
 
-t_vector	tangent_to_model(t_vector tangent, t_vector t, t_vector b, t_vector n)
+t_vector	tangent_to_model(
+	t_vector tangent,
+	t_vector t,
+	t_vector b,
+	t_vector n)
 {
 	const t_vector	normal = ({
 			t_vector	res;

--- a/src/read_rt_file.c
+++ b/src/read_rt_file.c
@@ -1,0 +1,109 @@
+#include "../include/scene.h"
+#include "../include/free.h"
+#include "../minilibx-linux/mlx.h"
+
+static const char	*g_env_idents[] = {"A", "C", "L", NULL};
+static const char	*g_obj_idents[] =
+	{"sp", "pl", "cy", "co", "sl", "#", "ch", "bm", "tx", NULL};
+
+static char	*check_duplicated_identifier(char *ident, unsigned int *ident_flag)
+{
+	int			i;
+
+	i = 0;
+	while (g_obj_idents[i])
+		if (!ft_strcmp(ident, g_obj_idents[i++]))
+			return (NO_ERR);
+	i = 0;
+	while (g_env_idents[i])
+		if (!ft_strcmp(ident, g_env_idents[i++]))
+			break ;
+	if (((*ident_flag >> i) & 1) == 1)
+		return (ERR_DUPLICATE_IDENTIFIER);
+	*ident_flag |= (1 << i);
+	return (NO_ERR);
+}
+
+static char	*check_lack_of_identifier(unsigned int ident_flag)
+{
+	int	i;
+
+	i = 0;
+	while (g_env_idents[i++])
+		if (((ident_flag >> i) & 1) == 0)
+			return (ERR_LACK_IDENTIFIER);
+	return (NO_ERR);
+}
+
+static char	*classify_element(size_t num, char **info, t_program *p)
+{
+	if (num == 3 && !ft_strcmp(info[0], "A"))
+		return (load_ambient(p, &info[1]));
+	else if (num == 4 && !ft_strcmp(info[0], "C"))
+		return (load_camera(p, &info[1]));
+	else if (num == 4 && !ft_strcmp(info[0], "L"))
+		return (load_light(p, &info[1]));
+	else if ((num == 4 || num == 5) && !ft_strcmp(info[0], "sp"))
+		return (load_sphere(p, &info[1]));
+	else if ((num == 4 || num == 5) && !ft_strcmp(info[0], "pl"))
+		return (load_plane(p, &info[1]));
+	else if ((num == 6 || num == 7) && !ft_strcmp(info[0], "cy"))
+		return (load_cylinder(p, &info[1]));
+	else if (num == 6 && !ft_strcmp(info[0], "sl"))
+		return (load_spotlight(p, &info[1]));
+	else if ((num == 5 || num == 6) && !ft_strcmp(info[0], "co"))
+		return (load_cone(p, &info[1]));
+	else if (num == 5 && !ft_strcmp(info[0], "ch"))
+		return (load_checker(p, &info[1]));
+	else if (num == 4 && !ft_strcmp(info[0], "bm"))
+		return (load_bumpmap(p, &info[1]));
+	else if (num == 4 && !ft_strcmp(info[0], "tx"))
+		return (load_texture(p, &info[1]));
+	else if (ft_strcmp(info[0], "#"))
+		return (ERR_UNDEFINED_IDENTIFIER);
+	return (NO_ERR);
+}
+
+static char	*load_element(char *line, t_program *p, unsigned int *ident_flag)
+{
+	size_t	num;
+	char	**info;
+	char	*err;
+
+	info = x_split(line, ' ');
+	num = count_2d_array((void **)info);
+	err = classify_element(num, info, p);
+	if (err == NO_ERR)
+		err = check_duplicated_identifier(info[0], ident_flag);
+	free_2d_array((void ***)&info);
+	return (err);
+}
+
+char	*read_rt_file(char *filename, t_program *p)
+{
+	int					fd;
+	char				*line;
+	int					status;
+	char				*err;
+	static unsigned int	ident_flag;
+
+	err = NO_ERR;
+	fd = x_open(filename, O_RDONLY);
+	p->lights = make(sizeof(t_slice *), 0, 1);
+	p->objects = make(sizeof(t_slice *), 0, 1);
+	while (1)
+	{
+		status = x_get_next_line(fd, &line);
+		if (status == GNL_STATUS_DONE)
+			break ;
+		if (line[0] != '\0')
+			err = load_element(line, p, &ident_flag);
+		if (err != NO_ERR)
+			break ;
+	}
+	if (err == NO_ERR)
+		err = check_lack_of_identifier(ident_flag);
+	free(line);
+	x_close(fd);
+	return (err);
+}

--- a/src/rt_params.c
+++ b/src/rt_params.c
@@ -8,7 +8,7 @@ char	*load_ambient(t_program *p, char **info)
 	if (!(ft_strtod(info[0], &ratio) && 0.0 <= ratio && ratio <= 1.0))
 		return (ERR_MISCONFIGURED_AMBIENT);
 	if (get_color_from_str(info[1], &c) && check_color_range(c, 0.0, 255.0))
-		p->ambient = ambient(color_mult(color_mult(c, (double)1/255), ratio));
+		p->ambient = ambient(color_mult(color_mult(c, (double)1 / 255), ratio));
 	else
 		return (ERR_MISCONFIGURED_AMBIENT);
 	return (NO_ERR);
@@ -47,9 +47,11 @@ char	*load_light(t_program *p, char **info)
 			return (ERR_MISCONFIGURED_LIGHT);
 		if (!(ft_strtod(info[1], &ratio) && 0.0 <= ratio && ratio <= 1.0))
 			return (ERR_MISCONFIGURED_LIGHT);
-		if (!(get_color_from_str(info[2], &c) && check_color_range(c, 0.0, 255.0)))
+		if (!(get_color_from_str(info[2], &c)
+				&& check_color_range(c, 0.0, 255.0)))
 			return (ERR_MISCONFIGURED_LIGHT);
-		light_ctor(get(l, 0), pos, color_mult(color_mult(c, (double)1/255), ratio));
+		light_ctor(get(l, 0), pos, \
+			color_mult(color_mult(c, (double)1 / 255), ratio));
 		l;
 	});
 
@@ -57,10 +59,9 @@ char	*load_light(t_program *p, char **info)
 	return (NO_ERR);
 }
 
-
 char	*load_spotlight(t_program *p, char **info)
 {
-	const	t_slice *spotlight = ({
+	const t_slice	*spotlight = ({
 			t_slice		*sp = make(sizeof(t_spotlight), 1, 1);
 			t_vector	pos;
 			t_vector	dir;
@@ -76,9 +77,11 @@ char	*load_spotlight(t_program *p, char **info)
 				return (ERR_MISCONFIGURED_SPOTLIGHT);
 			if (!(ft_strtod(info[3], &ratio) && 0.0 <= ratio && ratio <= 1.0))
 				return (ERR_MISCONFIGURED_SPOTLIGHT);
-			if (!(get_color_from_str(info[4], &c) && check_color_range(c, 0.0, 255.0)))
+			if (!(get_color_from_str(info[4], &c)
+					&& check_color_range(c, 0.0, 255.0)))
 				return (ERR_MISCONFIGURED_SPOTLIGHT);
-			spotlight_ctor(get(sp, 0), pos, color_mult(color_mult(c, (double)1/255), ratio), dir, fov);
+			spotlight_ctor(get(sp, 0), pos, \
+				color_mult(color_mult(c, (double)1 / 255), ratio), dir, fov);
 			sp;
 	});
 

--- a/src/rt_params_obj_info.c
+++ b/src/rt_params_obj_info.c
@@ -12,9 +12,11 @@ char	*load_checker(t_program *p, char **info)
 	if (object->info.flag & (1 << FLAG_CHECKER))
 		return (ERR_DUPLICATE_MATERIAL);
 	object->info.flag |= (1 << FLAG_CHECKER);
-	if (!(atoi_strict(info[0], &object->info.ch_freq_u) && 1 <= object->info.ch_freq_u))
+	if (!(atoi_strict(info[0], &object->info.ch_freq_u)
+			&& 1 <= object->info.ch_freq_u))
 		return (ERR_MISCONFIGURED_CHECKER);
-	if (!(atoi_strict(info[1], &object->info.ch_freq_v) && 1 <= object->info.ch_freq_v))
+	if (!(atoi_strict(info[1], &object->info.ch_freq_v)
+			&& 1 <= object->info.ch_freq_v))
 		return (ERR_MISCONFIGURED_CHECKER);
 	if (!(get_color_from_str(info[2], &c) && check_color_range(c, 0.0, 255.0)))
 		return (ERR_MISCONFIGURED_CHECKER);
@@ -37,18 +39,19 @@ char	*load_bumpmap(t_program *p, char **info)
 		return (ERR_DUPLICATE_MATERIAL);
 	object->info.flag |= (1 << FLAG_BUMPMAP);
 	img = &object->info.bm_image;
-	img->image = NULL;
-	img->buffer = NULL;
-	img->image = mlx_xpm_file_to_image(p->mlx, info[0], &img->width, &img->height);
+	img->image = \
+		mlx_xpm_file_to_image(p->mlx, info[0], &img->width, &img->height);
 	if (!img->image)
 		return (ERR_MISCONFIGURED_BUMPMAP);
 	img->buffer = mlx_get_data_addr(img->image,
 			 &img->bits_per_pixel, &img->size_line, &img->endian);
 	if (!img->buffer)
 		return (ERR_MISCONFIGURED_BUMPMAP);
-	if (!(atoi_strict(info[1], &object->info.bm_freq_u) && 1 <= object->info.bm_freq_u))
+	if (!(atoi_strict(info[1], &object->info.bm_freq_u)
+			&& 1 <= object->info.bm_freq_u))
 		return (ERR_MISCONFIGURED_BUMPMAP);
-	if (!(atoi_strict(info[2], &object->info.bm_freq_v) && 1 <= object->info.bm_freq_v))
+	if (!(atoi_strict(info[2], &object->info.bm_freq_v)
+			&& 1 <= object->info.bm_freq_v))
 		return (ERR_MISCONFIGURED_BUMPMAP);
 	return (NO_ERR);
 }
@@ -65,18 +68,19 @@ char	*load_texture(t_program *p, char **info)
 		return (ERR_DUPLICATE_MATERIAL);
 	object->info.flag |= (1 << FLAG_TEXTURE);
 	img = &object->info.tx_image;
-	img->image = NULL;
-	img->buffer = NULL;
-	img->image = mlx_xpm_file_to_image(p->mlx, info[0], &img->width, &img->height);
+	img->image = \
+		mlx_xpm_file_to_image(p->mlx, info[0], &img->width, &img->height);
 	if (!img->image)
 		return (ERR_MISCONFIGURED_TEXTURE);
 	img->buffer = mlx_get_data_addr(img->image,
 			 &img->bits_per_pixel, &img->size_line, &img->endian);
 	if (!img->buffer)
 		return (ERR_MISCONFIGURED_TEXTURE);
-	if (!(atoi_strict(info[1], &object->info.tx_freq_u) && 1 <= object->info.tx_freq_u))
+	if (!(atoi_strict(info[1], &object->info.tx_freq_u)
+			&& 1 <= object->info.tx_freq_u))
 		return (ERR_MISCONFIGURED_TEXTURE);
-	if (!(atoi_strict(info[2], &object->info.tx_freq_v) && 1 <= object->info.tx_freq_v))
+	if (!(atoi_strict(info[2], &object->info.tx_freq_v)
+			&& 1 <= object->info.tx_freq_v))
 		return (ERR_MISCONFIGURED_TEXTURE);
 	return (NO_ERR);
 }

--- a/src/scene.c
+++ b/src/scene.c
@@ -1,113 +1,4 @@
 #include "../include/scene.h"
-#include "../include/free.h"
-#include "../minilibx-linux/mlx.h"
-
-static const char	*g_env_idents[] = {"A", "C", "L", NULL};
-static const char	*g_obj_idents[] = {"sp", "pl", "cy", "co", "sl", "#", "ch", "bm", "tx", NULL};
-
-static char	*check_duplicated_identifier(char *ident, unsigned int *ident_flag)
-{
-	int			i;
-
-	i = 0;
-	while (g_obj_idents[i])
-		if (!ft_strcmp(ident, g_obj_idents[i++]))
-			return (NO_ERR);
-	i = 0;
-	while (g_env_idents[i])
-		if (!ft_strcmp(ident, g_env_idents[i++]))
-			break ;
-	if (((*ident_flag >> i) & 1) == 1)
-		return (ERR_DUPLICATE_IDENTIFIER);
-	*ident_flag |= (1 << i);
-	return (NO_ERR);
-}
-
-static char	*check_lack_of_identifier(unsigned int ident_flag)
-{
-	int	i;
-
-	i = 0;
-	while (g_env_idents[i++])
-		if (((ident_flag >> i) & 1) == 0)
-			return (ERR_LACK_IDENTIFIER);
-	return (NO_ERR);
-}
-
-static char	*load_element(char *line, t_program *p, unsigned int *ident_flag)
-{
-	size_t	num;
-	char	**info;
-	char	*err;
-
-	err = NO_ERR;
-	info = x_split(line, ' ');
-	num = count_2d_array((void **)info);
-	if (num == 3 && !ft_strcmp(info[0], "A"))
-		err = load_ambient(p, &info[1]);
-	else if (num == 4 && !ft_strcmp(info[0], "C"))
-		err = load_camera(p, &info[1]);
-	else if (num == 4 && !ft_strcmp(info[0], "L"))
-		err = load_light(p, &info[1]);
-	else if ((num == 4 || num == 5) && !ft_strcmp(info[0], "sp"))
-		err = load_sphere(p, &info[1]);
-	else if ((num == 4 || num == 5) && !ft_strcmp(info[0], "pl"))
-		err = load_plane(p, &info[1]);
-	else if ((num == 6 || num == 7) && !ft_strcmp(info[0], "cy"))
-		err = load_cylinder(p, &info[1]);
-	else if (num == 6 && !ft_strcmp(info[0], "sl"))
-		err = load_spotlight(p, &info[1]);
-	else if ((num == 5 || num == 6) && !ft_strcmp(info[0], "co"))
-		err = load_cone(p, &info[1]);
-	else if (num == 5 && !ft_strcmp(info[0], "ch"))
-		err = load_checker(p, &info[1]);
-	else if (num == 4 && !ft_strcmp(info[0], "bm"))
-		err = load_bumpmap(p, &info[1]);
-	else if (num == 4 && !ft_strcmp(info[0], "tx"))
-		err = load_texture(p, &info[1]);
-	else if (ft_strcmp(info[0], "#"))
-		err = ERR_UNDEFINED_IDENTIFIER;
-	if (err == NO_ERR)
-		err = check_duplicated_identifier(info[0], ident_flag);
-	free_2d_array((void ***)&info);
-	return (err);
-}
-
-static void	read_rt_file(char *filename, t_program *p)
-{
-	int					fd;
-	char				*line;
-	int					status;
-	char				*err;
-	static unsigned int	ident_flag;
-
-	err = NO_ERR;
-	fd = x_open(filename, O_RDONLY);
-	p->lights = make(sizeof(t_slice *), 0, 1);
-	p->objects = make(sizeof(t_slice *), 0, 1);
-	while (1)
-	{
-		status = x_get_next_line(fd, &line);
-		if (status == GNL_STATUS_DONE)
-			break ;
-		if (line[0] != '\0')
-			err = load_element(line, p, &ident_flag);
-		if (err != NO_ERR)
-			break ;
-	}
-	if (err == NO_ERR)
-		err = check_lack_of_identifier(ident_flag);
-	free(line);
-	x_close(fd);
-	if (err != NO_ERR)
-	{
-		destroy_object_images(p);
-		delete_recursively(p->lights, 1);
-		delete_recursively(p->objects, 1);
-		mlx_destroy_display(p->mlx);
-		exit_with_error_message(err);
-	}
-}
 
 static bool	check_filename(char *filename)
 {
@@ -123,9 +14,20 @@ static bool	check_filename(char *filename)
 
 void	load_rt_file(int argc, char **argv, t_program *p)
 {
+	char	*err;
+
 	if (argc != 2)
 		exit_with_error_message(ERR_INVALID_ARGS);
 	if (!check_filename(argv[1]))
 		exit_with_error_message(ERR_INVALID_FILE);
-	read_rt_file(argv[1], p);
+	err = read_rt_file(argv[1], p);
+	if (err != NO_ERR)
+	{
+		// TODO: destroy all
+		// destroy_object_images(p);
+		// delete_recursively(p->lights, 1);
+		// delete_recursively(p->objects, 1);
+		// mlx_destroy_display(p->mlx);
+		exit_with_error_message(err);
+	}
 }

--- a/src/scene.c
+++ b/src/scene.c
@@ -18,7 +18,7 @@ static char	*check_duplicated_identifier(char *ident, unsigned int *ident_flag)
 		if (!ft_strcmp(ident, g_env_idents[i++]))
 			break ;
 	if (((*ident_flag >> i) & 1) == 1)
-		return (ERR_DUPLICATE_CAPITAL_IDENTIFIER);
+		return (ERR_DUPLICATE_IDENTIFIER);
 	*ident_flag |= (1 << i);
 	return (NO_ERR);
 }
@@ -30,7 +30,7 @@ static char	*check_lack_of_identifier(unsigned int ident_flag)
 	i = 0;
 	while (g_env_idents[i++])
 		if (((ident_flag >> i) & 1) == 0)
-			return (ERR_LACK_CAPITAL_IDENTIFIER);
+			return (ERR_LACK_IDENTIFIER);
 	return (NO_ERR);
 }
 


### PR DESCRIPTION
## 実装内容
<!--
どういう実装にしたか
 -->
- `LINE_TOO_LONG`, `TOO_MANY_LINES`などの簡単に対応できるNormに対応
- `scene.c`内の各識別子を読み込んでいく処理は関数が多くなりすぎてしまったため、`read_rt_file.c`というファイルに分割した
- 上記変更に伴って、`rt`ファイル読み込み中にエラーが発生した場合の処理を`scene.c`内の`load_rt_file()`関数で一貫して行うように変更（エラー発生時の`mlx_destroy_***`, `free`等の後処理は未実装）

## レビュー観点
<!--
どういった箇所を中心にレビューして欲しいか
 -->
- 多分ロジック自体はそこまで変わってないはず
- コンパイルはOK
- `texture.rt`, `bumpmap.rt`とか修正した範囲で影響のありそうな`rt`ファイルでの実行もOK

## 変更の種類
<!--
・新機能
・バグ修正
・リファクタリング
・ドキュメント作成・更新
・その他
 -->
<!-- ## テスト
・パラメータ（バグが起こったもの、新しく追加したもの等）
・環境
など、必要に応じて書く
 -->

## メモ

## レビュー優先度
1. すぐに見てもらいたい（hotfixなど） 🚀
2. 今日中に見てもらいたい 🚗
3. 今日〜明日中で見てもらいたい 🚶
4. 数日以内で見てもらいたい 🐢
