### PR TITLE
Style/norm moromin🐢

### DIFF
--- a/include/object.h
+++ b/include/object.h
@@ -109,12 +109,15 @@ typedef struct s_cone
 	t_vector	e2;
 }	t_cone;
 
-void		cone_ctor(
-				t_cone *me,
-				t_vector center,
-				t_vector normal,
-				double aperture,
-				t_color k_diffuse,
-				t_color k_specular);
+typedef struct s_cone_attrs
+{
+	t_vector	center;
+	t_vector	normal;
+	double		aperture;
+	t_color		k_diffuse;
+	t_color		k_specular;
+}	t_cone_attrs;
+
+void		cone_ctor(t_cone *me, t_cone_attrs attrs);
 
 #endif

--- a/include/object.h
+++ b/include/object.h
@@ -100,7 +100,9 @@ typedef struct s_cylinder_attrs
 	t_color		k_specular;
 }	t_cylinder_attrs;
 
-void		cylinder_ctor(t_cylinder *me, t_cylinder_attrs attrs);
+void		cylinder_ctor(
+				t_cylinder *me,
+				t_cylinder_attrs *attrs);
 
 // cone
 typedef struct s_cone
@@ -121,6 +123,8 @@ typedef struct s_cone_attrs
 	t_color		k_specular;
 }	t_cone_attrs;
 
-void		cone_ctor(t_cone *me, t_cone_attrs attrs);
+void		cone_ctor(
+				t_cone *me,
+				t_cone_attrs *attrs);
 
 #endif

--- a/include/object.h
+++ b/include/object.h
@@ -90,14 +90,17 @@ typedef struct s_cylinder
 	t_vector	e2;
 }	t_cylinder;
 
-void		cylinder_ctor(
-				t_cylinder *me,
-				t_vector center,
-				t_vector normal,
-				double radius,
-				double height,
-				t_color k_diffuse,
-				t_color k_specular);
+typedef struct s_cylinder_attrs
+{
+	t_vector	center;
+	t_vector	normal;
+	double		radius;
+	double		height;
+	t_color		k_diffuse;
+	t_color		k_specular;
+}	t_cylinder_attrs;
+
+void		cylinder_ctor(t_cylinder *me, t_cylinder_attrs attrs);
 
 // cone
 typedef struct s_cone

--- a/include/private_object_method.h
+++ b/include/private_object_method.h
@@ -13,6 +13,17 @@ t_vector	sphere_calc_normal(t_object *me, t_vector cross_point);
 t_vector	sphere_calc_bumpmap_normal(t_object *me, t_vector cross_point);
 t_color		sphere_calc_color(t_object *me_, t_vector cross_point);
 
+// cylinder methods
+double		cylinder_solve_ray_equation(t_object *me, t_ray ray);
+t_vector	cylinder_calc_normal(t_object *me, t_vector cross_point);
+t_vector	cylinder_calc_bumpmap_normal(t_object *me, t_vector cross_point);
+t_color		cylinder_calc_color(t_object *me, t_vector cross_point);
+double		cylinder_solve_ray_equation_helper(
+				t_ray ray,
+				double t_outer,
+				double t_inner,
+				const t_cylinder *me);
+
 // cone methods
 double		cone_solve_ray_equation(t_object *me, t_ray ray);
 t_vector	cone_calc_normal(t_object *me, t_vector cross_point);

--- a/include/private_object_method.h
+++ b/include/private_object_method.h
@@ -1,15 +1,22 @@
 #ifndef PRIVATE_OBJECT_METHOD_H
 # define PRIVATE_OBJECT_METHOD_H
 
+// plane methods
 double		plane_solve_ray_equation(t_object *me, t_ray ray);
 t_vector	plane_calc_normal(t_object *me, t_vector cross_point);
 t_vector	plane_calc_bumpmap_normal(t_object *me, t_vector cross_point);
 t_color		plane_calc_color(t_object *me_, t_vector cross_point);
-t_uv		plane_calc_uv(const t_plane *me, t_vector cross_point);
 
+// sphere methods
 double		sphere_solve_ray_equation(t_object *me, t_ray ray);
 t_vector	sphere_calc_normal(t_object *me, t_vector cross_point);
 t_vector	sphere_calc_bumpmap_normal(t_object *me, t_vector cross_point);
 t_color		sphere_calc_color(t_object *me_, t_vector cross_point);
+
+// cone methods
+double		cone_solve_ray_equation(t_object *me, t_ray ray);
+t_vector	cone_calc_normal(t_object *me, t_vector cross_point);
+t_vector	cone_calc_bumpmap_normal(t_object *me, t_vector cross_point);
+t_color		cone_calc_color(t_object *me, t_vector cross_point);
 
 #endif

--- a/include/scene.h
+++ b/include/scene.h
@@ -47,7 +47,7 @@
 // Warning messages
 # define WARNING_NOT_NORMALIZED YELLOW"Not normalized vector found (We normalized it for you!)"RESET
 
-# define DEF_K_SPECULAR 204
+# define K_SPECULAR 204
 
 // scene.c
 void	load_rt_file(int argc, char **argv, t_program *program);

--- a/include/scene.h
+++ b/include/scene.h
@@ -65,9 +65,9 @@ char	*load_bumpmap(t_program *p, char **info);
 char	*load_texture(t_program *p, char **info);
 
 // rt_params_obj.c
-char	*load_sphere(t_program *p, char **info, size_t params);
-char	*load_plane(t_program *p, char **info, size_t params);
-char	*load_cylinder(t_program *p, char **info, size_t params);
-char	*load_cone(t_program *p, char **info, size_t params);
+char	*load_sphere(t_program *p, char **info, size_t param_num);
+char	*load_plane(t_program *p, char **info, size_t param_num);
+char	*load_cylinder(t_program *p, char **info, size_t param_num);
+char	*load_cone(t_program *p, char **info, size_t param_num);
 
 #endif

--- a/include/scene.h
+++ b/include/scene.h
@@ -42,10 +42,10 @@
 # define ERR_MISCONFIGURED_CHECKER "Checker is misconfigured"
 # define ERR_MISCONFIGURED_BUMPMAP "Bumpmap is misconfigured"
 # define ERR_MISCONFIGURED_TEXTURE "Texture is misconfigured"
-# define ERR_DUPLICATE_MATERIAL "Material parameter has already been specified."
+# define ERR_DUPLICATE_MATERIAL "Material parameter has already been specified"
 
 // Warning messages
-# define WARNING_NOT_NORMALIZED YELLOW"Not normalized vector found (We normalized it for you!)"RESET
+# define WARNING_NOT_NORMALIZED "Not normalized vector found, we normalized it!"
 
 # define K_SPECULAR 204
 
@@ -65,9 +65,9 @@ char	*load_bumpmap(t_program *p, char **info);
 char	*load_texture(t_program *p, char **info);
 
 // rt_params_obj.c
-char	*load_sphere(t_program *p, char **info);
-char	*load_plane(t_program *p, char **info);
-char	*load_cylinder(t_program *p, char **info);
-char	*load_cone(t_program *p, char **info);
+char	*load_sphere(t_program *p, char **info, size_t params);
+char	*load_plane(t_program *p, char **info, size_t params);
+char	*load_cylinder(t_program *p, char **info, size_t params);
+char	*load_cone(t_program *p, char **info, size_t params);
 
 #endif

--- a/src/cone.c
+++ b/src/cone.c
@@ -9,7 +9,7 @@ static t_vector	calc_bumpmap_normal(t_object *me, t_vector cross_point);
 static t_color	calc_color(t_object *me, t_vector cross_point);
 static t_uv		calc_uv(const t_cone *me, t_vector cross_point);
 
-void	cone_ctor(t_cone *me, t_cone_attrs attrs)
+void	cone_ctor(t_cone *me, t_cone_attrs *attrs)
 {
 	static t_object_vtbl	vtbl = {
 			.solve_ray_equation = &solve_ray_equation,
@@ -20,17 +20,17 @@ void	cone_ctor(t_cone *me, t_cone_attrs attrs)
 	const t_vector			e1 = ({
 		const t_vector	ex = vec_init(1, 0, 0);
 		t_vector	vec;
-		if (vec_dot(attrs.normal, ex) == 1)
+		if (vec_dot(attrs->normal, ex) == 1)
 			vec = ex;
 		else
-			vec = vec_cross(attrs.normal, ex);
+			vec = vec_cross(attrs->normal, ex);
 		vec;
 	});
 
-	object_ctor(&me->super, attrs.center, attrs.k_diffuse, attrs.k_specular);
+	object_ctor(&me->super, attrs->center, attrs->k_diffuse, attrs->k_specular);
 	me->super.vptr = &vtbl;
-	me->normal = attrs.normal;
-	me->aperture = attrs.aperture;
+	me->normal = attrs->normal;
+	me->aperture = attrs->aperture;
 	me->e1 = e1;
 	me->e2 = vec_cross(e1, me->normal);
 }

--- a/src/cone.c
+++ b/src/cone.c
@@ -9,13 +9,7 @@ static t_vector	calc_bumpmap_normal(t_object *me, t_vector cross_point);
 static t_color	calc_color(t_object *me, t_vector cross_point);
 static t_uv		calc_uv(const t_cone *me, t_vector cross_point);
 
-void	cone_ctor(
-			t_cone *me,
-			t_vector center,
-			t_vector normal,
-			double aperture,
-			t_color diffuse_reflection_coefficient,
-			t_color specular_reflection_coefficient)
+void	cone_ctor(t_cone *me, t_cone_attrs attrs)
 {
 	static t_object_vtbl	vtbl = {
 			.solve_ray_equation = &solve_ray_equation,
@@ -26,17 +20,17 @@ void	cone_ctor(
 	const t_vector			e1 = ({
 		const t_vector	ex = vec_init(1, 0, 0);
 		t_vector	vec;
-		if (vec_dot(normal, ex) == 1)
+		if (vec_dot(attrs.normal, ex) == 1)
 			vec = ex;
 		else
-			vec = vec_cross(normal, ex);
+			vec = vec_cross(attrs.normal, ex);
 		vec;
 	});
 
-	object_ctor(&me->super, center, diffuse_reflection_coefficient, specular_reflection_coefficient);
+	object_ctor(&me->super, attrs.center, attrs.k_diffuse, attrs.k_specular);
 	me->super.vptr = &vtbl;
-	me->normal = normal;
-	me->aperture = aperture;
+	me->normal = attrs.normal;
+	me->aperture = attrs.aperture;
 	me->e1 = e1;
 	me->e2 = vec_cross(e1, me->normal);
 }

--- a/src/cone.c
+++ b/src/cone.c
@@ -1,21 +1,13 @@
 #include "../include/object.h"
-#include "../include/math.h"
-#include "../include/obj_info.h"
-#include <math.h>
-
-static double	solve_ray_equation(t_object *me, t_ray ray);
-static t_vector	calc_normal(t_object *me, t_vector cross_point);
-static t_vector	calc_bumpmap_normal(t_object *me, t_vector cross_point);
-static t_color	calc_color(t_object *me, t_vector cross_point);
-static t_uv		calc_uv(const t_cone *me, t_vector cross_point);
+#include "../include/private_object_method.h"
 
 void	cone_ctor(t_cone *me, t_cone_attrs *attrs)
 {
 	static t_object_vtbl	vtbl = {
-			.solve_ray_equation = &solve_ray_equation,
-			.calc_normal = &calc_normal,
-			.calc_bumpmap_normal = &calc_bumpmap_normal,
-			.calc_color = &calc_color,
+			.solve_ray_equation = &cone_solve_ray_equation,
+			.calc_normal = &cone_calc_normal,
+			.calc_bumpmap_normal = &cone_calc_bumpmap_normal,
+			.calc_color = &cone_calc_color,
 	};
 	const t_vector			e1 = ({
 		const t_vector	ex = vec_init(1, 0, 0);
@@ -33,119 +25,4 @@ void	cone_ctor(t_cone *me, t_cone_attrs *attrs)
 	me->aperture = attrs->aperture;
 	me->e1 = e1;
 	me->e2 = vec_cross(e1, me->normal);
-}
-
-double	solve_ray_equation(t_object *const me_, t_ray ray)
-{
-	const t_cone	*me = (t_cone *)me_;
-	const double	t = ({
-			double			res;
-			const double	k = cos(me->aperture / 2 / 180 * M_PI);
-			const t_vector	q = vec_sub(ray.start, me->super.center);
-
-			const t_vector	B = vec_mult(ray.direction, k);
-			const t_vector	Q = vec_mult(q, k);
-			const double	R = vec_dot(ray.direction, me->normal);
-			const double	S = vec_dot(q, me->normal);
-
-			const double	a = vec_magnitude_squared(B) - pow(R, 2);
-			const double	b = 2 * (vec_dot(B, Q) - R * S);
-			const double	c = vec_magnitude_squared(Q) - pow(S, 2);
-			const double	d = pow(b, 2) - 4 * a * c;
-
-			if (a == 0)
-				return (-1 * c / b);
-			else if (d < 0)
-				return (-1.0);
-
-			double			t_outer = (-1 * b - sqrt(d)) / (2 * a);
-			double			t_inner = (-1 * b + sqrt(d)) / (2 * a);
-
-			if (t_outer < 0)
-				t_outer = INFINITY;
-			if (t_inner < 0)
-				t_inner = INFINITY;
-			if (t_outer == INFINITY && t_inner == INFINITY)
-				res = -1.0;
-			else
-				res = min(t_outer, t_inner);
-			res;
-	});
-
-	return (t);
-}
-
-static t_vector	calc_normal(t_object *const me_, t_vector cross_point)
-{
-	const t_cone	*me = (t_cone *)me_;
-	const t_vector	normal = ({
-			t_vector		direction = me->normal;
-			const t_vector	center_to_cross = vec_normalize(vec_sub(cross_point, me->super.center));
-
-			if (vec_dot(center_to_cross, direction) < 0)
-				direction = vec_mult(direction, -1);
-			vec_normalize(vec_sub(vec_mult(center_to_cross, cos(me->aperture / 2 / 180 * M_PI)), direction));
-	});
-
-	return (normal);
-}
-
-static t_vector	calc_bumpmap_normal(t_object *const me_, t_vector cross_point)
-{
-	const t_cone	*me = (t_cone *)me_;
-	const t_vector	normal = ({
-			t_uv			uv = calc_uv(me, cross_point);
-			const t_vector	tangent = get_vector_from_normal_map(uv.u, uv.v, &me->super.info);
-
-			t_vector		direction = me->normal;
-			if (vec_dot(vec_sub(cross_point, me->super.center), direction) < 0)
-				direction = vec_mult(direction, -1);
-
-			const t_vector	n = object_calc_normal(me_, cross_point);
-			const t_vector	t = vec_normalize(vec_cross(direction, n));
-			const t_vector	b = vec_normalize(vec_cross(t, n));
-
-			tangent_to_model(tangent, t, b, n);
-	});
-
-	return (normal);
-}
-
-static t_color	calc_color(t_object *const me_, t_vector cross_point)
-{
-	const t_cone	*me = (t_cone *)me_;
-	const t_color	c = ({
-		t_color c;
-		if (me->super.info.flag & 1 << FLAG_CHECKER)
-			c = ch_color_at(&me->super.info, calc_uv(me, cross_point));
-		else if (me->super.info.flag & 1 << FLAG_TEXTURE)
-			c = tx_color_at(&me->super.info, calc_uv(me, cross_point));
-		else
-			c = me->super.material.k_diffuse;
-		c;
-	});
-
-	return (c);
-}
-
-static t_uv	calc_uv(const t_cone *const me, t_vector cross_point)
-{
-	const t_uv	uv = ({
-		t_uv	uv;
-		double	integer;
-		const t_vector	center2cross = vec_sub(cross_point, me->super.center);
-		// checkerの変数v (0 <= v <= 1)
-		uv.v = modf(vec_dot(center2cross, me->normal), &integer);
-		// 基底ベクトル1方向への大きさ（-pi <= n1 <= p1）
-		const double n1 = vec_dot(center2cross, me->e1);
-		const double n2 = vec_dot(center2cross, me->e2);
-		// 方位角 (-pi < phi <= pi)
-		const double phi = atan2(n1, n2);
-		uv.u = phi / (2 * M_PI) + 0.5;
-		if (uv.v < 0)
-			uv.v *= -1;
-		uv;
-	});
-
-	return (uv);
 }

--- a/src/cone_method.c
+++ b/src/cone_method.c
@@ -1,0 +1,114 @@
+#include <math.h>
+
+#include "../include/color.h"
+#include "../include/material.h"
+#include "../include/math.h"
+#include "../include/object.h"
+
+static t_uv	cone_calc_uv(const t_cone *const me, t_vector cross_point);
+
+double	cone_solve_ray_equation(t_object *const me_, t_ray ray)
+{
+	const t_cone	*me = (t_cone *)me_;
+	const double	t = ({
+		double			res;
+		const double	k = cos(me->aperture / 2 / 180 * M_PI);
+		const t_vector	q = vec_sub(ray.start, me->super.center);
+		const t_vector	B = vec_mult(ray.direction, k);
+		const t_vector	Q = vec_mult(q, k);
+		const double	R = vec_dot(ray.direction, me->normal);
+		const double	S = vec_dot(q, me->normal);
+		const double	a = vec_magnitude_squared(B) - pow(R, 2);
+		const double	b = 2 * (vec_dot(B, Q) - R * S);
+		const double	c = vec_magnitude_squared(Q) - pow(S, 2);
+		const double	d = pow(b, 2) - 4 * a * c;
+		if (a == 0) return (-1 * c / b);
+		else if (d < 0)	return (-1.0);
+		double			t_outer = (-1 * b - sqrt(d)) / (2 * a);
+		double			t_inner = (-1 * b + sqrt(d)) / (2 * a);
+		if (t_outer < 0) t_outer = INFINITY;
+		if (t_inner < 0) t_inner = INFINITY;
+		if (t_outer == INFINITY && t_inner == INFINITY)	res = -1.0;
+		else res = min(t_outer, t_inner);
+		res;
+	});
+
+	return (t);
+}
+
+t_vector	cone_calc_normal(t_object *me_, t_vector cross_point)
+{
+	const t_cone	*me = (t_cone *)me_;
+	const t_vector	normal = ({
+		t_vector		direction = me->normal;
+		const t_vector	center_to_cross =
+				vec_normalize(vec_sub(cross_point, me->super.center));
+
+		if (vec_dot(center_to_cross, direction) < 0)
+			direction = vec_mult(direction, -1);
+		vec_normalize(vec_sub(vec_mult(\
+			center_to_cross, cos(me->aperture / 2 / 180 * M_PI)), direction));
+	});
+
+	return (normal);
+}
+
+t_vector	cone_calc_bumpmap_normal(
+	t_object *const me_,
+	t_vector cross_point)
+{
+	const t_cone	*me = (t_cone *)me_;
+	const t_vector	normal = ({
+		t_uv			uv = cone_calc_uv(me, cross_point);
+		const t_vector	tangent =
+				get_vector_from_normal_map(uv.u, uv.v, &me->super.info);
+
+		t_vector		direction = me->normal;
+		if (vec_dot(vec_sub(cross_point, me->super.center), direction) < 0)
+			direction = vec_mult(direction, -1);
+
+		const t_vector	n = object_calc_normal(me_, cross_point);
+		const t_vector	t = vec_normalize(vec_cross(direction, n));
+		const t_vector	b = vec_normalize(vec_cross(t, n));
+
+		tangent_to_model(tangent, t, b, n);
+	});
+
+	return (normal);
+}
+
+t_color	cone_calc_color(t_object *const me_, t_vector cross_point)
+{
+	const t_cone	*me = (t_cone *)me_;
+	const t_color	c = ({
+		t_color c;
+		if (me->super.info.flag & 1 << FLAG_CHECKER)
+			c = ch_color_at(&me->super.info, cone_calc_uv(me, cross_point));
+		else if (me->super.info.flag & 1 << FLAG_TEXTURE)
+			c = tx_color_at(&me->super.info, cone_calc_uv(me, cross_point));
+		else
+			c = me->super.material.k_diffuse;
+		c;
+	});
+
+	return (c);
+}
+
+t_uv	cone_calc_uv(const t_cone *const me, t_vector cross_point)
+{
+	const t_uv	uv = ({
+		t_uv	uv;
+		double	integer;
+		const t_vector	center2cross = vec_sub(cross_point, me->super.center);
+		uv.v = modf(vec_dot(center2cross, me->normal), &integer);
+		const double n1 = vec_dot(center2cross, me->e1);
+		const double n2 = vec_dot(center2cross, me->e2);
+		const double phi = atan2(n1, n2);
+		uv.u = phi / (2 * M_PI) + 0.5;
+		if (uv.v < 0)
+			uv.v *= -1;
+		uv;
+	});
+
+	return (uv);
+}

--- a/src/cylinder.c
+++ b/src/cylinder.c
@@ -1,22 +1,13 @@
-#include <math.h>
-#include <printf.h>
-
 #include "../include/object.h"
-#include "../include/math.h"
-
-static double	solve_ray_equation(t_object *me, t_ray ray);
-static t_vector	calc_normal(t_object *me, t_vector cross_point);
-static t_vector	calc_bumpmap_normal(t_object *me, t_vector cross_point);
-static t_color	calc_color(t_object *me, t_vector cross_point);
-static t_uv		calc_uv(const t_cylinder *const me, t_vector cross_point);
+#include "../include/private_object_method.h"
 
 void	cylinder_ctor(t_cylinder *me, t_cylinder_attrs *attrs)
 {
 	static t_object_vtbl	vtbl = {
-			.solve_ray_equation = &solve_ray_equation,
-			.calc_normal = &calc_normal,
-			.calc_bumpmap_normal = &calc_bumpmap_normal,
-			.calc_color = &calc_color,
+			.solve_ray_equation = &cylinder_solve_ray_equation,
+			.calc_normal = &cylinder_calc_normal,
+			.calc_bumpmap_normal = &cylinder_calc_bumpmap_normal,
+			.calc_color = &cylinder_calc_color,
 	};
 	const t_vector			e1 = ({
 		const t_vector	ex = vec_init(1, 0, 0);
@@ -35,117 +26,4 @@ void	cylinder_ctor(t_cylinder *me, t_cylinder_attrs *attrs)
 	me->normal = attrs->normal;
 	me->e1 = e1;
 	me->e2 = vec_cross(e1, me->normal);
-}
-
-double	solve_ray_equation(t_object *me_, t_ray ray)
-{
-	const t_cylinder	*me = (t_cylinder *)me_;
-	const double		t = ({
-		const double	a = vec_magnitude_squared(vec_cross(ray.direction, me->normal));
-		if (a == 0)
-			return (-1.0);
-
-		const double	b = 2 * (vec_dot(
-				vec_cross(ray.direction, me->normal),
-				vec_cross(vec_sub(ray.start, me->super.center), me->normal)));
-		const double	c = vec_magnitude_squared(vec_cross(
-				vec_sub(ray.start, me->super.center),
-				me->normal)) - pow(me->radius, 2);
-		const double	d = pow(b, 2) - 4 * a * c;
-		const double	t_inner = (-1 * b + sqrt(d)) / (2 * a);
-		const double	t_outer = (-1 * b - sqrt(d)) / (2 * a);
-		double			res;
-
-		if (d < 0 || (t_inner < 0 && t_outer < 0))
-			res = -1.0;
-		else
-		{
-			const t_vector	outer = vec_add(ray.start, vec_mult(ray.direction, t_outer));
-			const t_vector	inner = vec_add(ray.start, vec_mult(ray.direction, t_inner));
-
-			const t_vector	center_to_outer = vec_sub(outer, me->super.center);
-			const t_vector	center_to_inner = vec_sub(inner, me->super.center);
-
-			const double	outer_height = vec_dot(center_to_outer, me->normal);
-			const double	inner_height = vec_dot(center_to_inner, me->normal);
-
-			if (t_outer >= 0.0 && 0.0 <= outer_height && outer_height <= me->height)
-				res = t_outer;
-			else if (t_inner >= 0.0 && 0.0 <= inner_height && inner_height <= me->height)
-				res = t_inner;
-			else
-				res = -1.0;
-		}
-		res;
-	});
-
-	return (t);
-}
-
-t_vector	calc_normal(t_object *const me_, t_vector cross_point)
-{
-	const t_cylinder	*me = (t_cylinder *)me_;
-	const t_vector		normal = ({
-		const t_vector	center_to_cross = vec_sub(cross_point, me->super.center);
-		const double	h = vec_dot(center_to_cross, me->normal);
-
-		vec_normalize(vec_sub(center_to_cross, vec_mult(me->normal, h)));
-	});
-
-	return (normal);
-}
-
-t_vector	calc_bumpmap_normal(t_object *const me_, t_vector cross_point)
-{
-	const t_cylinder	*me = (t_cylinder *)me_;
-	const t_vector		normal = ({
-		const t_uv		uv = calc_uv(me, cross_point);
-		const t_vector	tangent = get_vector_from_normal_map(uv.u, uv.v, &me->super.info);
-
-		const t_vector	n = object_calc_normal(me_, cross_point);
-		const t_vector	b = me->normal;
-		const t_vector	t = vec_cross(b, n);
-
-		tangent_to_model(tangent, t, b, n);
-	});
-
-	return (normal);
-}
-
-static t_color	calc_color(t_object *const me_, t_vector cross_point)
-{
-	const t_cylinder	*me = (t_cylinder *)me_;
-	const t_color c = ({
-		t_color c;
-		if (me->super.info.flag & 1 << FLAG_CHECKER)
-			c = ch_color_at(&me->super.info, calc_uv(me, cross_point));
-		else if (me->super.info.flag & 1 << FLAG_TEXTURE)
-			c = tx_color_at(&me->super.info, calc_uv(me, cross_point));
-		else
-			c = me->super.material.k_diffuse;
-		c;
-	});
-	return (c);
-}
-
-static t_uv 	calc_uv(const t_cylinder *const me, t_vector cross_point)
-{
-	const t_uv	uv = ({
-		t_uv	uv;
-		const t_vector	n_center2cross = vec_normalize(vec_sub(cross_point, me->super.center));
-		// 仰角 (0 <= theta <= max_theta)
-		const double theta = M_PI / 2 - acos(vec_dot(n_center2cross, me->normal));
-		const double height = tan(theta) * me->radius;
-		// checkerの変数v (0 <= v <= 1)
-		uv.v = 1 - height / me->height;
-		// 基底ベクトル1方向への大きさ（-pi <= n1 <= p1）
-		const double n1 = vec_dot(n_center2cross, me->e1);
-		const double n2 = vec_dot(n_center2cross, me->e2);
-		// 方位角 (-pi < phi <= pi)
-		const double phi = atan2(n1, n2);
-		uv.u = 1 - (phi / (2 * M_PI) + 0.5);
-		uv;
-	});
-
-	return (uv);
 }

--- a/src/cylinder.c
+++ b/src/cylinder.c
@@ -10,7 +10,7 @@ static t_vector	calc_bumpmap_normal(t_object *me, t_vector cross_point);
 static t_color	calc_color(t_object *me, t_vector cross_point);
 static t_uv		calc_uv(const t_cylinder *const me, t_vector cross_point);
 
-void	cylinder_ctor(t_cylinder *me, t_cylinder_attrs attrs)
+void	cylinder_ctor(t_cylinder *me, t_cylinder_attrs *attrs)
 {
 	static t_object_vtbl	vtbl = {
 			.solve_ray_equation = &solve_ray_equation,
@@ -21,18 +21,18 @@ void	cylinder_ctor(t_cylinder *me, t_cylinder_attrs attrs)
 	const t_vector			e1 = ({
 		const t_vector	ex = vec_init(1, 0, 0);
 		t_vector	vec;
-		if (vec_dot(attrs.normal, ex) == 1)
+		if (vec_dot(attrs->normal, ex) == 1)
 			vec = ex;
 		else
-			vec = vec_cross(attrs.normal, ex);
+			vec = vec_cross(attrs->normal, ex);
 		vec;
 	});
 
-	object_ctor(&me->super, attrs.center, attrs.k_diffuse, attrs.k_specular);
+	object_ctor(&me->super, attrs->center, attrs->k_diffuse, attrs->k_specular);
 	me->super.vptr = &vtbl;
-	me->radius = attrs.radius;
-	me->height = attrs.height;
-	me->normal = attrs.normal;
+	me->radius = attrs->radius;
+	me->height = attrs->height;
+	me->normal = attrs->normal;
 	me->e1 = e1;
 	me->e2 = vec_cross(e1, me->normal);
 }

--- a/src/cylinder.c
+++ b/src/cylinder.c
@@ -8,16 +8,9 @@ static double	solve_ray_equation(t_object *me, t_ray ray);
 static t_vector	calc_normal(t_object *me, t_vector cross_point);
 static t_vector	calc_bumpmap_normal(t_object *me, t_vector cross_point);
 static t_color	calc_color(t_object *me, t_vector cross_point);
-static t_uv 	calc_uv(const t_cylinder *const me, t_vector cross_point);
+static t_uv		calc_uv(const t_cylinder *const me, t_vector cross_point);
 
-void	cylinder_ctor(
-		t_cylinder *me,
-		t_vector center,
-		t_vector normal,
-		double radius,
-		double height,
-		t_color diffuse_reflection_coefficient,
-		t_color specular_reflection_coefficient)
+void	cylinder_ctor(t_cylinder *me, t_cylinder_attrs attrs)
 {
 	static t_object_vtbl	vtbl = {
 			.solve_ray_equation = &solve_ray_equation,
@@ -28,18 +21,18 @@ void	cylinder_ctor(
 	const t_vector			e1 = ({
 		const t_vector	ex = vec_init(1, 0, 0);
 		t_vector	vec;
-		if (vec_dot(normal, ex) == 1)
+		if (vec_dot(attrs.normal, ex) == 1)
 			vec = ex;
 		else
-			vec = vec_cross(normal, ex);
+			vec = vec_cross(attrs.normal, ex);
 		vec;
 	});
 
-	object_ctor(&me->super, center, diffuse_reflection_coefficient, specular_reflection_coefficient);
+	object_ctor(&me->super, attrs.center, attrs.k_diffuse, attrs.k_specular);
 	me->super.vptr = &vtbl;
-	me->radius = radius;
-	me->height = height;
-	me->normal = normal;
+	me->radius = attrs.radius;
+	me->height = attrs.height;
+	me->normal = attrs.normal;
 	me->e1 = e1;
 	me->e2 = vec_cross(e1, me->normal);
 }

--- a/src/cylinder_method.c
+++ b/src/cylinder_method.c
@@ -1,0 +1,107 @@
+#include <math.h>
+
+#include "../include/color.h"
+#include "../include/material.h"
+#include "../include/math.h"
+#include "../include/object.h"
+#include "../include/private_object_method.h"
+
+static t_uv	cylinder_calc_uv(const t_cylinder *const me, t_vector cross_point);
+
+double	cylinder_solve_ray_equation(t_object *me_, t_ray ray)
+{
+	const t_cylinder	*me = (t_cylinder *)me_;
+	const double		t = ({
+		const double	a =
+				vec_magnitude_squared(vec_cross(ray.direction, me->normal));
+		if (a == 0)
+			return (-1.0);
+		const double	b = 2 * (vec_dot(
+				vec_cross(ray.direction, me->normal),
+				vec_cross(vec_sub(ray.start, me->super.center), me->normal)));
+		const double	c = vec_magnitude_squared(vec_cross(
+				vec_sub(ray.start, me->super.center),
+				me->normal)) - pow(me->radius, 2);
+		const double	d = pow(b, 2) - 4 * a * c;
+		const double	t_inner = (-1 * b + sqrt(d)) / (2 * a);
+		const double	t_outer = (-1 * b - sqrt(d)) / (2 * a);
+		double			res;
+		if (d < 0 || (t_inner < 0 && t_outer < 0))
+			res = -1.0;
+		else
+			res = cylinder_solve_ray_equation_helper(ray, t_outer, t_inner, me);
+		res;
+	});
+
+	return (t);
+}
+
+t_vector	cylinder_calc_normal(t_object *const me_, t_vector cross_point)
+{
+	const t_cylinder	*me = (t_cylinder *)me_;
+	const t_vector		normal = ({
+		const t_vector	center2cross =
+				vec_sub(cross_point, me->super.center);
+		const double	h = vec_dot(center2cross, me->normal);
+
+		vec_normalize(vec_sub(center2cross, vec_mult(me->normal, h)));
+	});
+
+	return (normal);
+}
+
+t_vector	cylinder_calc_bumpmap_normal(
+	t_object *const me_,
+	t_vector cross_point)
+{
+	const t_cylinder	*me = (t_cylinder *)me_;
+	const t_vector		normal = ({
+		const t_uv		uv = cylinder_calc_uv(me, cross_point);
+		const t_vector	tangent =
+			get_vector_from_normal_map(uv.u, uv.v, &me->super.info);
+		const t_vector	n = object_calc_normal(me_, cross_point);
+		const t_vector	b = me->normal;
+		const t_vector	t = vec_cross(b, n);
+
+		tangent_to_model(tangent, t, b, n);
+	});
+
+	return (normal);
+}
+
+t_color	cylinder_calc_color(t_object *const me_, t_vector cross_point)
+{
+	const t_cylinder	*me = (t_cylinder *)me_;
+	const t_color		c = ({
+		t_color c;
+		if (me->super.info.flag & 1 << FLAG_CHECKER)
+			c = ch_color_at(&me->super.info, cylinder_calc_uv(me, cross_point));
+		else if (me->super.info.flag & 1 << FLAG_TEXTURE)
+			c = tx_color_at(&me->super.info, cylinder_calc_uv(me, cross_point));
+		else
+			c = me->super.material.k_diffuse;
+		c;
+	});
+
+	return (c);
+}
+
+t_uv	cylinder_calc_uv(const t_cylinder *const me, t_vector cross_point)
+{
+	const t_uv	uv = ({
+		t_uv	uv;
+		const t_vector	n_center2cross =
+				vec_normalize(vec_sub(cross_point, me->super.center));
+		const double theta =
+				M_PI / 2 - acos(vec_dot(n_center2cross, me->normal));
+		const double height = tan(theta) * me->radius;
+		uv.v = 1 - height / me->height;
+		const double n1 = vec_dot(n_center2cross, me->e1);
+		const double n2 = vec_dot(n_center2cross, me->e2);
+		const double phi = atan2(n1, n2);
+		uv.u = 1 - (phi / (2 * M_PI) + 0.5);
+		uv;
+	});
+
+	return (uv);
+}

--- a/src/cylinder_method_helper.c
+++ b/src/cylinder_method_helper.c
@@ -1,0 +1,32 @@
+#include <math.h>
+
+#include "../include/object.h"
+
+double	cylinder_solve_ray_equation_helper(
+	t_ray ray,
+	double t_outer,
+	double t_inner,
+	const t_cylinder *me)
+{
+	const double	res = ({
+		double			res;
+		const t_vector	outer =
+			vec_add(ray.start, vec_mult(ray.direction, t_outer));
+		const t_vector	inner =
+			vec_add(ray.start, vec_mult(ray.direction, t_inner));
+		const t_vector	center2outer = vec_sub(outer, me->super.center);
+		const t_vector	center2inner = vec_sub(inner, me->super.center);
+		const double	outer_height = vec_dot(center2outer, me->normal);
+		const double	inner_height = vec_dot(center2inner, me->normal);
+		if (t_outer >= 0.0 && 0.0 <= outer_height && outer_height <= me->height)
+			res = t_outer;
+		else if (t_inner >= 0.0 && 0.0 <= inner_height
+				&& inner_height <= me->height)
+			res = t_inner;
+		else
+			res = -1.0;
+		res;
+	});
+
+	return (res);
+}

--- a/src/read_rt_file.c
+++ b/src/read_rt_file.c
@@ -44,15 +44,15 @@ static char	*classify_element(size_t num, char **info, t_program *p)
 	else if (num == 4 && !ft_strcmp(info[0], "L"))
 		return (load_light(p, &info[1]));
 	else if ((num == 4 || num == 5) && !ft_strcmp(info[0], "sp"))
-		return (load_sphere(p, &info[1]));
+		return (load_sphere(p, &info[1], num - 1));
 	else if ((num == 4 || num == 5) && !ft_strcmp(info[0], "pl"))
-		return (load_plane(p, &info[1]));
+		return (load_plane(p, &info[1], num - 1));
 	else if ((num == 6 || num == 7) && !ft_strcmp(info[0], "cy"))
-		return (load_cylinder(p, &info[1]));
+		return (load_cylinder(p, &info[1], num - 1));
+	else if ((num == 5 || num == 6) && !ft_strcmp(info[0], "co"))
+		return (load_cone(p, &info[1], num - 1));
 	else if (num == 6 && !ft_strcmp(info[0], "sl"))
 		return (load_spotlight(p, &info[1]));
-	else if ((num == 5 || num == 6) && !ft_strcmp(info[0], "co"))
-		return (load_cone(p, &info[1]));
 	else if (num == 5 && !ft_strcmp(info[0], "ch"))
 		return (load_checker(p, &info[1]));
 	else if (num == 4 && !ft_strcmp(info[0], "bm"))

--- a/src/rt_params.c
+++ b/src/rt_params.c
@@ -25,7 +25,7 @@ char	*load_camera(t_program *p, char **info)
 		return (ERR_MISCONFIGURED_CAMERA);
 	if (vec_magnitude_squared(p->camera.normal) != 1)
 	{
-		ft_putendl_fd(WARNING_NOT_NORMALIZED, STDERR_FILENO);
+		ft_putendl_fd(YELLOW WARNING_NOT_NORMALIZED RESET, STDERR_FILENO);
 		p->camera.normal = vec_normalize(p->camera.normal);
 	}
 	if (ft_strtod(info[2], &fov) && 0.0 <= fov && fov <= 180.0)
@@ -62,27 +62,23 @@ char	*load_light(t_program *p, char **info)
 char	*load_spotlight(t_program *p, char **info)
 {
 	const t_slice	*spotlight = ({
-			t_slice		*sp = make(sizeof(t_spotlight), 1, 1);
-			t_vector	pos;
-			t_vector	dir;
-			double		fov;
-			double		ratio;
-			t_color		c;
-			if (!get_vector_from_str(info[0], &pos))
-				return (ERR_MISCONFIGURED_SPOTLIGHT);
-			if (!get_vector_from_str(info[1], &dir))
-				return (ERR_MISCONFIGURED_SPOTLIGHT);
-			if (!(ft_strtod(info[2], &fov) && 0.0 <= fov && fov <= 360))
-				return (ERR_MISCONFIGURED_SPOTLIGHT);
-			if (!(ft_strtod(info[3], &ratio) && 0.0 <= ratio && ratio <= 1.0))
-				return (ERR_MISCONFIGURED_SPOTLIGHT);
-			if (!(get_color_from_str(info[4], &c)
-					&& check_color_range(c, 0.0, 255.0)))
-				return (ERR_MISCONFIGURED_SPOTLIGHT);
-			t_spotlight_attrs attrs = {pos, \
-			   color_mult(color_mult(c, (double)1 / 255), ratio), dir, fov};
-			spotlight_ctor(get(sp, 0), &attrs);
-			sp;
+		t_slice		*sp = make(sizeof(t_spotlight), 1, 1);
+		t_vector	pos;
+		t_vector	dir;
+		double		fov;
+		double		ratio;
+		t_color		c;
+		if (!(get_vector_from_str(info[0], &pos)
+			&& get_vector_from_str(info[1], &dir)
+			&& (ft_strtod(info[2], &fov) && 0.0 <= fov && fov <= 360.0)
+			&& (ft_strtod(info[3], &ratio) && 0.0 <= ratio && ratio <= 1.0)
+			&& (get_color_from_str(info[4], &c)
+				&& check_color_range(c, 0.0, 255.0))))
+			return (ERR_MISCONFIGURED_SPOTLIGHT);
+		t_spotlight_attrs attrs = {pos, \
+			color_mult(color_mult(c, (double)1 / 255), ratio), dir, fov};
+		spotlight_ctor(get(sp, 0), &attrs);
+		sp;
 	});
 
 	append(p->lights, &spotlight);

--- a/src/rt_params_obj.c
+++ b/src/rt_params_obj.c
@@ -4,25 +4,23 @@ char	*load_sphere(t_program *p, char **info)
 {
 	const t_slice	*sphere = ({
 		const t_slice	*sp = make(sizeof(t_sphere), 1, 1);
-		t_vector		center;
-		double			radius;
-		t_color			k_diffuse;
-		t_color			k_specular;
+		t_sphere_attrs	attrs;
 
-		if (!get_vector_from_str(info[0], &center))
+		if (!get_vector_from_str(info[0], &attrs.center))
 			return (ERR_MISCONFIGURED_SPHERE);
-		if (!ft_strtod(info[1], &radius))
+		if (!ft_strtod(info[1], &attrs.radius))
 			return (ERR_MISCONFIGURED_SPHERE);
-		radius /= 2;
-		if (!(get_color_from_str(info[2], &k_diffuse)
-				&& check_color_range(k_diffuse, 0.0, 255.0)))
+		attrs.radius /= 2;
+		if (!(get_color_from_str(info[2], &attrs.k_diffuse)
+				&& check_color_range(attrs.k_diffuse, 0.0, 255.0)))
 			return (ERR_MISCONFIGURED_SPHERE);
-		k_specular = color(DEF_K_SPECULAR, DEF_K_SPECULAR, DEF_K_SPECULAR);
+		attrs.k_specular = color(K_SPECULAR, K_SPECULAR, K_SPECULAR);
 		if (count_2d_array((void **)info) == 4
-			&& !(get_color_from_str(info[3], &k_specular)
-				&& check_color_range(k_specular, 0.0, 255.0)))
+			&& !(get_color_from_str(info[3], &attrs.k_specular)
+				&& check_color_range(attrs.k_specular, 0.0, 255.0)))
 			return (ERR_MISCONFIGURED_SPHERE);
-		t_sphere_attrs attrs = {radius, center,color_mult(k_diffuse, (double)1 / 255),color_mult(k_specular, (double)1 / 255)};
+		attrs.k_diffuse = color_mult(attrs.k_diffuse, (double)1 / 255);
+		attrs.k_specular = color_mult(attrs.k_specular, (double)1 / 255);
 		sphere_ctor(get(sp, 0), &attrs);
 		sp;
 	});
@@ -35,30 +33,28 @@ char	*load_plane(t_program *p, char **info)
 {
 	const t_slice	*plane = ({
 		const t_slice	*pl = make(sizeof(t_plane), 1, 1);
-		t_vector		center;
-		t_vector		normal;
-		t_color			k_diffuse;
-		t_color			k_specular;
+		t_plane_attrs	attrs;
 
-		if (!get_vector_from_str(info[0], &center))
+		if (!get_vector_from_str(info[0], &attrs.center))
 			return (ERR_MISCONFIGURED_PLANE);
-		if (!(get_vector_from_str(info[1], &normal)
-			  && check_vector_range(normal, -1.0, 1.0)))
+		if (!(get_vector_from_str(info[1], &attrs.normal)
+			  && check_vector_range(attrs.normal, -1.0, 1.0)))
 			return (ERR_MISCONFIGURED_PLANE);
-		if (vec_magnitude_squared(normal) != 1)
+		if (vec_magnitude_squared(attrs.normal) != 1)
 		{
 			ft_putendl_fd(WARNING_NOT_NORMALIZED, STDERR_FILENO);
-			normal = vec_normalize(normal);
+			attrs.normal = vec_normalize(attrs.normal);
 		}
-		if (!(get_color_from_str(info[2], &k_diffuse)
-			  && check_color_range(k_diffuse, 0.0, 255.0)))
+		if (!(get_color_from_str(info[2], &attrs.k_diffuse)
+			  && check_color_range(attrs.k_diffuse, 0.0, 255.0)))
 			return (ERR_MISCONFIGURED_PLANE);
-		k_specular = color(DEF_K_SPECULAR, DEF_K_SPECULAR, DEF_K_SPECULAR);
+		attrs.k_specular = color(K_SPECULAR, K_SPECULAR, K_SPECULAR);
 		if (count_2d_array((void **)info) == 4
-			&& !(get_color_from_str(info[3], &k_specular)
-				 && check_color_range(k_specular, 0.0, 255.0)))
+			&& !(get_color_from_str(info[3], &attrs.k_specular)
+				 && check_color_range(attrs.k_specular, 0.0, 255.0)))
 			return (ERR_MISCONFIGURED_PLANE);
-		t_plane_attrs attrs = {center, normal,color_mult(k_diffuse, (double)1 / 255),color_mult(k_specular, (double)1 / 255)};
+		attrs.k_diffuse = color_mult(attrs.k_diffuse, (double)1 / 255);
+		attrs.k_specular = color_mult(attrs.k_specular, (double)1 / 255);
 		plane_ctor(get(pl, 0), &attrs);
 		pl;
 	});
@@ -91,14 +87,14 @@ char	*load_cylinder(t_program *p, char **info)
 		if (!(get_color_from_str(info[4], &attrs.k_diffuse)
 			&& check_color_range(attrs.k_diffuse, 0.0, 255.0)))
 			return (ERR_MISCONFIGURED_CYLINDER);
-		attrs.k_specular = color(DEF_K_SPECULAR, DEF_K_SPECULAR, DEF_K_SPECULAR);
+		attrs.k_specular = color(K_SPECULAR, K_SPECULAR, K_SPECULAR);
 		if (count_2d_array((void **)info) == 6
 			&& !(get_color_from_str(info[5], &attrs.k_specular)
 			&& check_color_range(attrs.k_specular, 0.0, 255.0)))
 			return (ERR_MISCONFIGURED_CYLINDER);
 		attrs.k_diffuse = color_mult(attrs.k_diffuse, (double)1 / 255);
 		attrs.k_specular = color_mult(attrs.k_specular, (double)1 / 255);
-		cylinder_ctor(get(cy, 0), attrs);
+		cylinder_ctor(get(cy, 0), &attrs);
 		cy;
 	});
 
@@ -109,34 +105,34 @@ char	*load_cylinder(t_program *p, char **info)
 char	*load_cone(t_program *p, char **info)
 {
 	const t_slice	*cone = ({
-			t_slice			*co = make(sizeof(t_cone), 1, 1);
-			t_cone_attrs	attrs;
+		t_slice			*co = make(sizeof(t_cone), 1, 1);
+		t_cone_attrs	attrs;
 
-			if (!get_vector_from_str(info[0], &attrs.center))
-				return (ERR_MISCONFIGURED_CONE);
-			if (!(get_vector_from_str(info[1], &attrs.normal)
-				&& check_vector_range(attrs.normal, -1.0, 1.0)))
-				return (ERR_MISCONFIGURED_CONE);
-			if (vec_magnitude_squared(attrs.normal) != 1)
-			{
-				ft_putendl_fd(WARNING_NOT_NORMALIZED, STDERR_FILENO);
-				attrs.normal = vec_normalize(attrs.normal);
-			}
-			if (!(ft_strtod(info[2], &attrs.aperture)
-				&& 0.0 <= attrs.aperture && attrs.aperture < 180.0))
-				return (ERR_MISCONFIGURED_CONE);
-			if (!(get_color_from_str(info[3], &attrs.k_diffuse)
-				&& check_color_range(attrs.k_diffuse, 0.0, 255.0)))
-				return (ERR_MISCONFIGURED_CONE);
-			attrs.k_specular = color(DEF_K_SPECULAR, DEF_K_SPECULAR, DEF_K_SPECULAR);
-			if (count_2d_array((void **)info) == 5
-				&& !(get_color_from_str(info[4], &attrs.k_specular)
-				&& check_color_range(attrs.k_specular, 0.0, 255.0)))
-				return (ERR_MISCONFIGURED_CONE);
-			attrs.k_diffuse = color_mult(attrs.k_diffuse, (double)1 / 255);
-			attrs.k_specular = color_mult(attrs.k_specular, (double)1 / 255);
-			cone_ctor(get(co, 0), attrs);
-			co;
+		if (!get_vector_from_str(info[0], &attrs.center))
+			return (ERR_MISCONFIGURED_CONE);
+		if (!(get_vector_from_str(info[1], &attrs.normal)
+			&& check_vector_range(attrs.normal, -1.0, 1.0)))
+			return (ERR_MISCONFIGURED_CONE);
+		if (vec_magnitude_squared(attrs.normal) != 1)
+		{
+			ft_putendl_fd(YELLOW WARNING_NOT_NORMALIZED RESET, STDERR_FILENO);
+			attrs.normal = vec_normalize(attrs.normal);
+		}
+		if (!(ft_strtod(info[2], &attrs.aperture)
+			&& 0.0 <= attrs.aperture && attrs.aperture < 180.0))
+			return (ERR_MISCONFIGURED_CONE);
+		if (!(get_color_from_str(info[3], &attrs.k_diffuse)
+			&& check_color_range(attrs.k_diffuse, 0.0, 255.0)))
+			return (ERR_MISCONFIGURED_CONE);
+		attrs.k_specular = color(K_SPECULAR, K_SPECULAR, K_SPECULAR);
+		if (count_2d_array((void **)info) == 5
+			&& !(get_color_from_str(info[4], &attrs.k_specular)
+			&& check_color_range(attrs.k_specular, 0.0, 255.0)))
+			return (ERR_MISCONFIGURED_CONE);
+		attrs.k_diffuse = color_mult(attrs.k_diffuse, (double)1 / 255);
+		attrs.k_specular = color_mult(attrs.k_specular, (double)1 / 255);
+		cone_ctor(get(co, 0), &attrs);
+		co;
 	});
 
 	append(p->objects, &cone);

--- a/src/rt_params_obj.c
+++ b/src/rt_params_obj.c
@@ -70,38 +70,35 @@ char	*load_plane(t_program *p, char **info)
 char	*load_cylinder(t_program *p, char **info)
 {
 	const t_slice		*cylinder = ({
-		t_slice		*cy = make(sizeof(t_cylinder), 1, 1);
-		t_vector	center;
-		t_vector	normal;
-		double		radius;
-		double		height;
-		t_color		k_diffuse;
-		t_color		k_specular;
+		t_slice				*cy = make(sizeof(t_cylinder), 1, 1);
+		t_cylinder_attrs	attrs;
 
-		if (!get_vector_from_str(info[0], &center))
+		if (!get_vector_from_str(info[0], &attrs.center))
 			return (ERR_MISCONFIGURED_CYLINDER);
-		if (!(get_vector_from_str(info[1], &normal)
-			&& check_vector_range(normal, -1.0, 1.0)))
+		if (!(get_vector_from_str(info[1], &attrs.normal)
+			&& check_vector_range(attrs.normal, -1.0, 1.0)))
 			return (ERR_MISCONFIGURED_CYLINDER);
-		if (vec_magnitude_squared(normal) != 1)
+		if (vec_magnitude_squared(attrs.normal) != 1)
 		{
 			ft_putendl_fd(WARNING_NOT_NORMALIZED, STDERR_FILENO);
-			normal = vec_normalize(normal);
+			attrs.normal = vec_normalize(attrs.normal);
 		}
-		if (!ft_strtod(info[2], &radius))
+		if (!ft_strtod(info[2], &attrs.radius))
 			return (ERR_MISCONFIGURED_CYLINDER);
-		radius /= 2;
-		if (!ft_strtod(info[3], &height))
+		attrs.radius /= 2;
+		if (!ft_strtod(info[3], &attrs.height))
 			return (ERR_MISCONFIGURED_CYLINDER);
-		if (!(get_color_from_str(info[4], &k_diffuse)
-			&& check_color_range(k_diffuse, 0.0, 255.0)))
+		if (!(get_color_from_str(info[4], &attrs.k_diffuse)
+			&& check_color_range(attrs.k_diffuse, 0.0, 255.0)))
 			return (ERR_MISCONFIGURED_CYLINDER);
-		k_specular = color(DEF_K_SPECULAR, DEF_K_SPECULAR, DEF_K_SPECULAR);
+		attrs.k_specular = color(DEF_K_SPECULAR, DEF_K_SPECULAR, DEF_K_SPECULAR);
 		if (count_2d_array((void **)info) == 6
-			&& !(get_color_from_str(info[5], &k_specular)
-			&& check_color_range(k_specular, 0.0, 255.0)))
+			&& !(get_color_from_str(info[5], &attrs.k_specular)
+			&& check_color_range(attrs.k_specular, 0.0, 255.0)))
 			return (ERR_MISCONFIGURED_CYLINDER);
-		cylinder_ctor(get(cy, 0), center, normal, radius, height, color_mult(k_diffuse, (double)1 / 255), color_mult(k_specular, (double)1 / 255));
+		attrs.k_diffuse = color_mult(attrs.k_diffuse, (double)1 / 255);
+		attrs.k_specular = color_mult(attrs.k_specular, (double)1 / 255);
+		cylinder_ctor(get(cy, 0), attrs);
 		cy;
 	});
 

--- a/src/rt_params_obj.c
+++ b/src/rt_params_obj.c
@@ -2,7 +2,7 @@
 
 static t_vector	normalize_object_normal_vector(t_vector normal);
 
-char	*load_sphere(t_program *p, char **info, size_t params)
+char	*load_sphere(t_program *p, char **info, size_t param_num)
 {
 	const t_slice	*sphere = ({
 		const t_slice	*sp = make(sizeof(t_sphere), 1, 1);
@@ -14,7 +14,7 @@ char	*load_sphere(t_program *p, char **info, size_t params)
 			&& (get_color_from_str(info[2], &attrs.k_diffuse)
 				&& check_color_range(attrs.k_diffuse, 0.0, 255.0))))
 			return (ERR_MISCONFIGURED_SPHERE);
-		if (params == 4 && !(get_color_from_str(info[3], &attrs.k_specular)
+		if (param_num == 4 && !(get_color_from_str(info[3], &attrs.k_specular)
 				&& check_color_range(attrs.k_specular, 0.0, 255.0)))
 			return (ERR_MISCONFIGURED_SPHERE);
 		attrs.radius /= 2;
@@ -28,7 +28,7 @@ char	*load_sphere(t_program *p, char **info, size_t params)
 	return (NO_ERR);
 }
 
-char	*load_plane(t_program *p, char **info, size_t params)
+char	*load_plane(t_program *p, char **info, size_t param_num)
 {
 	const t_slice	*plane = ({
 		const t_slice	*pl = make(sizeof(t_plane), 1, 1);
@@ -41,7 +41,7 @@ char	*load_plane(t_program *p, char **info, size_t params)
 			&& (get_color_from_str(info[2], &attrs.k_diffuse)
 				&& check_color_range(attrs.k_diffuse, 0.0, 255.0))))
 			return (ERR_MISCONFIGURED_PLANE);
-		if (params == 4 && !(get_color_from_str(info[3], &attrs.k_specular)
+		if (param_num == 4 && !(get_color_from_str(info[3], &attrs.k_specular)
 				&& check_color_range(attrs.k_specular, 0.0, 255.0)))
 			return (ERR_MISCONFIGURED_PLANE);
 		attrs.normal = normalize_object_normal_vector(attrs.normal);
@@ -55,7 +55,7 @@ char	*load_plane(t_program *p, char **info, size_t params)
 	return (NO_ERR);
 }
 
-char	*load_cylinder(t_program *p, char **info, size_t params)
+char	*load_cylinder(t_program *p, char **info, size_t param_num)
 {
 	const t_slice		*cylinder = ({
 		t_slice				*cy = make(sizeof(t_cylinder), 1, 1);
@@ -69,7 +69,7 @@ char	*load_cylinder(t_program *p, char **info, size_t params)
 			&& (get_color_from_str(info[4], &attrs.k_diffuse)
 				&& check_color_range(attrs.k_diffuse, 0.0, 255.0))))
 			return (ERR_MISCONFIGURED_CYLINDER);
-		if (params == 6 && !(get_color_from_str(info[5], &attrs.k_specular)
+		if (param_num == 6 && !(get_color_from_str(info[5], &attrs.k_specular)
 			&& check_color_range(attrs.k_specular, 0.0, 255.0)))
 			return (ERR_MISCONFIGURED_CYLINDER);
 		attrs.radius /= 2;
@@ -84,7 +84,7 @@ char	*load_cylinder(t_program *p, char **info, size_t params)
 	return (NO_ERR);
 }
 
-char	*load_cone(t_program *p, char **info, size_t params)
+char	*load_cone(t_program *p, char **info, size_t param_num)
 {
 	const t_slice	*cone = ({
 		t_slice			*co = make(sizeof(t_cone), 1, 1);
@@ -99,7 +99,7 @@ char	*load_cone(t_program *p, char **info, size_t params)
 			&& (get_color_from_str(info[3], &attrs.k_diffuse)
 				&& check_color_range(attrs.k_diffuse, 0.0, 255.0))))
 			return (ERR_MISCONFIGURED_CONE);
-		if (params == 5 && !(get_color_from_str(info[4], &attrs.k_specular)
+		if (param_num == 5 && !(get_color_from_str(info[4], &attrs.k_specular)
 			&& check_color_range(attrs.k_specular, 0.0, 255.0)))
 			return (ERR_MISCONFIGURED_CONE);
 		attrs.normal = normalize_object_normal_vector(attrs.normal);

--- a/src/rt_params_obj.c
+++ b/src/rt_params_obj.c
@@ -1,24 +1,23 @@
 #include "../include/scene.h"
 
-char	*load_sphere(t_program *p, char **info)
+static t_vector	normalize_object_normal_vector(t_vector normal);
+
+char	*load_sphere(t_program *p, char **info, size_t params)
 {
 	const t_slice	*sphere = ({
 		const t_slice	*sp = make(sizeof(t_sphere), 1, 1);
 		t_sphere_attrs	attrs;
 
-		if (!get_vector_from_str(info[0], &attrs.center))
-			return (ERR_MISCONFIGURED_SPHERE);
-		if (!ft_strtod(info[1], &attrs.radius))
-			return (ERR_MISCONFIGURED_SPHERE);
-		attrs.radius /= 2;
-		if (!(get_color_from_str(info[2], &attrs.k_diffuse)
-				&& check_color_range(attrs.k_diffuse, 0.0, 255.0)))
-			return (ERR_MISCONFIGURED_SPHERE);
 		attrs.k_specular = color(K_SPECULAR, K_SPECULAR, K_SPECULAR);
-		if (count_2d_array((void **)info) == 4
-			&& !(get_color_from_str(info[3], &attrs.k_specular)
+		if (!(get_vector_from_str(info[0], &attrs.center)
+			&& ft_strtod(info[1], &attrs.radius)
+			&& (get_color_from_str(info[2], &attrs.k_diffuse)
+				&& check_color_range(attrs.k_diffuse, 0.0, 255.0))))
+			return (ERR_MISCONFIGURED_SPHERE);
+		if (params == 4 && !(get_color_from_str(info[3], &attrs.k_specular)
 				&& check_color_range(attrs.k_specular, 0.0, 255.0)))
 			return (ERR_MISCONFIGURED_SPHERE);
+		attrs.radius /= 2;
 		attrs.k_diffuse = color_mult(attrs.k_diffuse, (double)1 / 255);
 		attrs.k_specular = color_mult(attrs.k_specular, (double)1 / 255);
 		sphere_ctor(get(sp, 0), &attrs);
@@ -29,30 +28,23 @@ char	*load_sphere(t_program *p, char **info)
 	return (NO_ERR);
 }
 
-char	*load_plane(t_program *p, char **info)
+char	*load_plane(t_program *p, char **info, size_t params)
 {
 	const t_slice	*plane = ({
 		const t_slice	*pl = make(sizeof(t_plane), 1, 1);
 		t_plane_attrs	attrs;
 
-		if (!get_vector_from_str(info[0], &attrs.center))
-			return (ERR_MISCONFIGURED_PLANE);
-		if (!(get_vector_from_str(info[1], &attrs.normal)
-			  && check_vector_range(attrs.normal, -1.0, 1.0)))
-			return (ERR_MISCONFIGURED_PLANE);
-		if (vec_magnitude_squared(attrs.normal) != 1)
-		{
-			ft_putendl_fd(WARNING_NOT_NORMALIZED, STDERR_FILENO);
-			attrs.normal = vec_normalize(attrs.normal);
-		}
-		if (!(get_color_from_str(info[2], &attrs.k_diffuse)
-			  && check_color_range(attrs.k_diffuse, 0.0, 255.0)))
-			return (ERR_MISCONFIGURED_PLANE);
 		attrs.k_specular = color(K_SPECULAR, K_SPECULAR, K_SPECULAR);
-		if (count_2d_array((void **)info) == 4
-			&& !(get_color_from_str(info[3], &attrs.k_specular)
-				 && check_color_range(attrs.k_specular, 0.0, 255.0)))
+		if (!(get_vector_from_str(info[0], &attrs.center)
+			&& (get_vector_from_str(info[1], &attrs.normal)
+				&& check_vector_range(attrs.normal, -1.0, 1.0))
+			&& (get_color_from_str(info[2], &attrs.k_diffuse)
+				&& check_color_range(attrs.k_diffuse, 0.0, 255.0))))
 			return (ERR_MISCONFIGURED_PLANE);
+		if (params == 4 && !(get_color_from_str(info[3], &attrs.k_specular)
+				&& check_color_range(attrs.k_specular, 0.0, 255.0)))
+			return (ERR_MISCONFIGURED_PLANE);
+		attrs.normal = normalize_object_normal_vector(attrs.normal);
 		attrs.k_diffuse = color_mult(attrs.k_diffuse, (double)1 / 255);
 		attrs.k_specular = color_mult(attrs.k_specular, (double)1 / 255);
 		plane_ctor(get(pl, 0), &attrs);
@@ -63,35 +55,25 @@ char	*load_plane(t_program *p, char **info)
 	return (NO_ERR);
 }
 
-char	*load_cylinder(t_program *p, char **info)
+char	*load_cylinder(t_program *p, char **info, size_t params)
 {
 	const t_slice		*cylinder = ({
 		t_slice				*cy = make(sizeof(t_cylinder), 1, 1);
 		t_cylinder_attrs	attrs;
-
-		if (!get_vector_from_str(info[0], &attrs.center))
-			return (ERR_MISCONFIGURED_CYLINDER);
-		if (!(get_vector_from_str(info[1], &attrs.normal)
-			&& check_vector_range(attrs.normal, -1.0, 1.0)))
-			return (ERR_MISCONFIGURED_CYLINDER);
-		if (vec_magnitude_squared(attrs.normal) != 1)
-		{
-			ft_putendl_fd(WARNING_NOT_NORMALIZED, STDERR_FILENO);
-			attrs.normal = vec_normalize(attrs.normal);
-		}
-		if (!ft_strtod(info[2], &attrs.radius))
-			return (ERR_MISCONFIGURED_CYLINDER);
-		attrs.radius /= 2;
-		if (!ft_strtod(info[3], &attrs.height))
-			return (ERR_MISCONFIGURED_CYLINDER);
-		if (!(get_color_from_str(info[4], &attrs.k_diffuse)
-			&& check_color_range(attrs.k_diffuse, 0.0, 255.0)))
-			return (ERR_MISCONFIGURED_CYLINDER);
 		attrs.k_specular = color(K_SPECULAR, K_SPECULAR, K_SPECULAR);
-		if (count_2d_array((void **)info) == 6
-			&& !(get_color_from_str(info[5], &attrs.k_specular)
+		if (!(get_vector_from_str(info[0], &attrs.center)
+			&& (get_vector_from_str(info[1], &attrs.normal)
+				&& check_vector_range(attrs.normal, -1.0, 1.0))
+			&& ft_strtod(info[2], &attrs.radius)
+			&& ft_strtod(info[3], &attrs.height)
+			&& (get_color_from_str(info[4], &attrs.k_diffuse)
+				&& check_color_range(attrs.k_diffuse, 0.0, 255.0))))
+			return (ERR_MISCONFIGURED_CYLINDER);
+		if (params == 6 && !(get_color_from_str(info[5], &attrs.k_specular)
 			&& check_color_range(attrs.k_specular, 0.0, 255.0)))
 			return (ERR_MISCONFIGURED_CYLINDER);
+		attrs.radius /= 2;
+		attrs.normal = normalize_object_normal_vector(attrs.normal);
 		attrs.k_diffuse = color_mult(attrs.k_diffuse, (double)1 / 255);
 		attrs.k_specular = color_mult(attrs.k_specular, (double)1 / 255);
 		cylinder_ctor(get(cy, 0), &attrs);
@@ -102,33 +84,25 @@ char	*load_cylinder(t_program *p, char **info)
 	return (NO_ERR);
 }
 
-char	*load_cone(t_program *p, char **info)
+char	*load_cone(t_program *p, char **info, size_t params)
 {
 	const t_slice	*cone = ({
 		t_slice			*co = make(sizeof(t_cone), 1, 1);
 		t_cone_attrs	attrs;
 
-		if (!get_vector_from_str(info[0], &attrs.center))
-			return (ERR_MISCONFIGURED_CONE);
-		if (!(get_vector_from_str(info[1], &attrs.normal)
-			&& check_vector_range(attrs.normal, -1.0, 1.0)))
-			return (ERR_MISCONFIGURED_CONE);
-		if (vec_magnitude_squared(attrs.normal) != 1)
-		{
-			ft_putendl_fd(YELLOW WARNING_NOT_NORMALIZED RESET, STDERR_FILENO);
-			attrs.normal = vec_normalize(attrs.normal);
-		}
-		if (!(ft_strtod(info[2], &attrs.aperture)
-			&& 0.0 <= attrs.aperture && attrs.aperture < 180.0))
-			return (ERR_MISCONFIGURED_CONE);
-		if (!(get_color_from_str(info[3], &attrs.k_diffuse)
-			&& check_color_range(attrs.k_diffuse, 0.0, 255.0)))
-			return (ERR_MISCONFIGURED_CONE);
 		attrs.k_specular = color(K_SPECULAR, K_SPECULAR, K_SPECULAR);
-		if (count_2d_array((void **)info) == 5
-			&& !(get_color_from_str(info[4], &attrs.k_specular)
+		if (!(get_vector_from_str(info[0], &attrs.center)
+			&& (get_vector_from_str(info[1], &attrs.normal)
+				&& check_vector_range(attrs.normal, -1.0, 1.0))
+			&& (ft_strtod(info[2], &attrs.aperture)
+				&& 0.0 <= attrs.aperture && attrs.aperture < 180.0)
+			&& (get_color_from_str(info[3], &attrs.k_diffuse)
+				&& check_color_range(attrs.k_diffuse, 0.0, 255.0))))
+			return (ERR_MISCONFIGURED_CONE);
+		if (params == 5 && !(get_color_from_str(info[4], &attrs.k_specular)
 			&& check_color_range(attrs.k_specular, 0.0, 255.0)))
 			return (ERR_MISCONFIGURED_CONE);
+		attrs.normal = normalize_object_normal_vector(attrs.normal);
 		attrs.k_diffuse = color_mult(attrs.k_diffuse, (double)1 / 255);
 		attrs.k_specular = color_mult(attrs.k_specular, (double)1 / 255);
 		cone_ctor(get(co, 0), &attrs);
@@ -137,4 +111,14 @@ char	*load_cone(t_program *p, char **info)
 
 	append(p->objects, &cone);
 	return (NO_ERR);
+}
+
+static t_vector	normalize_object_normal_vector(t_vector normal)
+{
+	if (vec_magnitude_squared(normal) != 1)
+	{
+		ft_putendl_fd(YELLOW WARNING_NOT_NORMALIZED RESET, STDERR_FILENO);
+		normal = vec_normalize(normal);
+	}
+	return (normal);
 }

--- a/src/rt_params_obj.c
+++ b/src/rt_params_obj.c
@@ -112,35 +112,33 @@ char	*load_cylinder(t_program *p, char **info)
 char	*load_cone(t_program *p, char **info)
 {
 	const t_slice	*cone = ({
-			t_slice		*co = make(sizeof(t_cone), 1, 1);
-			t_vector	center;
-			t_vector	normal;
-			double		aperture;
-			t_color		k_diffuse;
-			t_color		k_specular;
+			t_slice			*co = make(sizeof(t_cone), 1, 1);
+			t_cone_attrs	attrs;
 
-			if (!get_vector_from_str(info[0], &center))
+			if (!get_vector_from_str(info[0], &attrs.center))
 				return (ERR_MISCONFIGURED_CONE);
-			if (!(get_vector_from_str(info[1], &normal)
-				&& check_vector_range(normal, -1.0, 1.0)))
+			if (!(get_vector_from_str(info[1], &attrs.normal)
+				&& check_vector_range(attrs.normal, -1.0, 1.0)))
 				return (ERR_MISCONFIGURED_CONE);
-			if (vec_magnitude_squared(normal) != 1)
+			if (vec_magnitude_squared(attrs.normal) != 1)
 			{
 				ft_putendl_fd(WARNING_NOT_NORMALIZED, STDERR_FILENO);
-				normal = vec_normalize(normal);
+				attrs.normal = vec_normalize(attrs.normal);
 			}
-			if (!(ft_strtod(info[2], &aperture)
-				&& 0.0 <= aperture && aperture < 180.0))
+			if (!(ft_strtod(info[2], &attrs.aperture)
+				&& 0.0 <= attrs.aperture && attrs.aperture < 180.0))
 				return (ERR_MISCONFIGURED_CONE);
-			if (!(get_color_from_str(info[3], &k_diffuse)
-				&& check_color_range(k_diffuse, 0.0, 255.0)))
+			if (!(get_color_from_str(info[3], &attrs.k_diffuse)
+				&& check_color_range(attrs.k_diffuse, 0.0, 255.0)))
 				return (ERR_MISCONFIGURED_CONE);
-			k_specular = color(DEF_K_SPECULAR, DEF_K_SPECULAR, DEF_K_SPECULAR);
+			attrs.k_specular = color(DEF_K_SPECULAR, DEF_K_SPECULAR, DEF_K_SPECULAR);
 			if (count_2d_array((void **)info) == 5
-				&& !(get_color_from_str(info[4], &k_specular)
-				&& check_color_range(k_specular, 0.0, 255.0)))
+				&& !(get_color_from_str(info[4], &attrs.k_specular)
+				&& check_color_range(attrs.k_specular, 0.0, 255.0)))
 				return (ERR_MISCONFIGURED_CONE);
-			cone_ctor(get(co, 0), center, normal, aperture, color_mult(k_diffuse, (double)1 / 255), color_mult(k_specular, (double)1 / 255));
+			attrs.k_diffuse = color_mult(attrs.k_diffuse, (double)1 / 255);
+			attrs.k_specular = color_mult(attrs.k_specular, (double)1 / 255);
+			cone_ctor(get(co, 0), attrs);
 			co;
 	});
 


### PR DESCRIPTION
## 実装内容
<!--
どういう実装にしたか
 -->
- `***_attrs`構造体を用いて、`rt`ファイル読み込み処理とコンストラクタ周りをリファクタリング
- 正規化されていない法線ベクトルが指定されたとき、以下のようなメッセージを出すようにdefineしているが、normでどう足掻いてもエラーになってしまう。
```c
# define WARNING_NOT_NORMALIZED YELLOW"Not normalized vector found (We normalized it for you!)"RESET

```
```bash
Error: TOO_MANY_VALS        (line:  48, col:  78):      Too many values on define
Error: LINE_TOO_LONG        (line:  48, col: 101):      line too long
Error: TOO_MANY_VALS        (line:  48, col: 135):      Too many values on define
```

- そのため、以下のように呼び出し側で、`YELLOW`, `RESET`等を指定するようにした
```c
ft_putendl_fd(YELLOW WARNING_NOT_NORMALIZED RESET, STDERR_FILENO);
```

## レビュー観点
<!--
どういった箇所を中心にレビューして欲しいか
 -->
- ロジック自体は変えてないはずなので、軽くチェックおなしゃす（一部汚い書き方になっているところは申し訳ない。。。）
- ウィンドウの❌を押した際に、後処理失敗してエラー発生してるみたいなのでそこは未着手

## 変更の種類
<!--
・新機能
・バグ修正
・リファクタリング
・ドキュメント作成・更新
・その他
 -->
<!-- ## テスト
・パラメータ（バグが起こったもの、新しく追加したもの等）
・環境
など、必要に応じて書く
 -->
・リファクタリング

## メモ
- Norm対応のせいで、ゴミカスみたいに汚い書き方になってしまった。。。
- もっといい書き方あれば教えてください！

## レビュー優先度
1. すぐに見てもらいたい（hotfixなど） 🚀
2. 今日中に見てもらいたい 🚗
3. 今日〜明日中で見てもらいたい 🚶
4. 数日以内で見てもらいたい 🐢
