### PR TITLE
 🚗 fix: lighting bug

### DIFF
--- a/src/object_radiance.c
+++ b/src/object_radiance.c
@@ -86,7 +86,6 @@ static t_color	calc_radiance_specular(
 		t_light light,
 		t_vector camera2cross)
 {
-	t_vector		vec;
 	const t_vector	normal = ({\
 		t_vector n;
 		if (obj->info.flag & (1 << FLAG_BUMPMAP))
@@ -99,14 +98,14 @@ static t_color	calc_radiance_specular(
 	});
 	const t_vector	incident_direction
 		= vec_normalize(vec_sub(light.pos, cross_point));
-	const t_vector	specular = ({\
-		vec = vec_mult(normal, 2 * vec_dot(normal, incident_direction));
-		vec_sub(vec, incident_direction);
-	});
+	const t_vector	specular
+		= vec_sub(vec_mult(normal, 2 * vec_dot(normal, incident_direction)),
+			incident_direction);
 	const t_vector	cross_point_inverse_normalized
 		= vec_normalize(vec_mult(camera2cross, -1));
 
-	if (vec_dot(normal, incident_direction) >= 0 && vec_dot(vec, specular) >= 0)
+	if (vec_dot(normal, incident_direction) >= 0
+		&& vec_dot(cross_point_inverse_normalized, specular) >= 0)
 		return (color_mult(\
 			color_prod(obj->material.k_specular, light.intensity), \
 			pow(vec_dot(cross_point_inverse_normalized, specular), SHININESS)));


### PR DESCRIPTION
## 実装内容
<!--
どういう実装にしたか
 -->
計算の途中で使っている `vec` が最後の条件分岐に使われていた...😅
norm対応のための変更も入っている！debug協力ありがとうございました🙇

計算処理はこの部分↓

![Screen Shot 2022-11-12 at 13 35 53](https://user-images.githubusercontent.com/69781798/201457267-14db50d7-181d-4819-aff9-60b3c385b2c8.png)

https://knzw.tech/raytracing/?page_id=1288

問題なく表示できている！

![Screen Shot 2022-11-12 at 13 35 08](https://user-images.githubusercontent.com/69781798/201457238-d30456f7-6db6-4602-bd91-292cf52e6fb3.png)



## レビュー観点
<!--
どういった箇所を中心にレビューして欲しいか
 -->

## 変更の種類
・バグ修正
<!--
・新機能
・リファクタリング
・ドキュメント作成・更新
・その他
 -->
<!-- ## テスト
・パラメータ（バグが起こったもの、新しく追加したもの等）
・環境
など、必要に応じて書く
 -->

## メモ

## レビュー優先度
1. すぐに見てもらいたい（hotfixなど） 🚀
2. 今日中に見てもらいたい 🚗
3. 今日〜明日中で見てもらいたい 🚶
4. 数日以内で見てもらいたい 🐢
